### PR TITLE
add program_id to all

### DIFF
--- a/schemas/donor.json
+++ b/schemas/donor.json
@@ -3,6 +3,14 @@
   "description": "The collection of data elements related to a specific donor in a specific ICGC-ARGO program.",
   "fields": [
     {
+      "name": "program_id",
+      "valueType": "string",
+      "description": "Unique identifier of the ARGO program.",
+      "restrictions": {
+        "required": true
+      }
+    },
+    {
       "description": "Unique identifier of the donor, assigned by the data provider.",
       "name": "submitter_donor_id",
       "restrictions": {

--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -3,6 +3,14 @@
   "description": "The collection of data elements related to a donor's primary diagnosis. The primary diagnosis is the first diagnosed case of cancer in a donor.",
   "fields": [
     {
+      "name": "program_id",
+      "valueType": "string",
+      "description": "Unique identifier of the ARGO program.",
+      "restrictions": {
+        "required": true
+      }
+    },
+    {
       "name": "submitter_donor_id",
       "valueType": "string",
       "description": "Unique identifier of the donor, assigned by the data provider.",

--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -3,6 +3,14 @@
   "description": "The collection of data elements related to a donor's specimen. A specimen is any material sample taken for testing, diagnostic or research purposes.",
   "fields": [
     {
+      "name": "program_id",
+      "valueType": "string",
+      "description": "Unique identifier of the ARGO program.",
+      "restrictions": {
+        "required": true
+      }
+    },
+    {
       "name": "submitter_donor_id",
       "description": "Unique identifier of the donor, assigned by the data provider.",
       "valueType": "string",


### PR DESCRIPTION
As requesting in #argo-requirements, `program_id` has been added to all schemas. 

