### PR TITLE
add specimen_type fields/tumor_normal_designation

### DIFF
--- a/schemas/sample_registration.json
+++ b/schemas/sample_registration.json
@@ -36,7 +36,11 @@
       },
       "restrictions": {
         "required": true,
-        "codeList": ["Male", "Female", "Other"]
+        "codeList": [
+          "Male",
+          "Female",
+          "Other"
+        ]
       }
     },
     {
@@ -93,6 +97,21 @@
     },
     {
       "name": "tumour_normal_designation",
+      "valueType": "string",
+      "description": "Description of specimens tumour/normal status for data processing.",
+      "restrictions": {
+        "required": true,
+        "codeList": [
+          "Normal",
+          "Tumour"
+        ]
+      },
+      "meta": {
+        "core": true
+      }
+    },
+    {
+      "name": "specimen_type",
       "valueType": "string",
       "description": "Description of the kind of specimen that was collected with respect to tumour/normal tissue origin.",
       "restrictions": {


### PR DESCRIPTION
add specimen_type fields/tumor_normal_designation 

to facilitate adding a switch that matches the fields in the song payloads as well