### PR TITLE
Validation + Unit Tests for Specimen -> Tumour Grade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dictionary.json
+populated_dictionary.json
 /coverage

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ You will be prompted to provide the dictionary name and version number, or leave
 If all tests do not pass, the dictionary will not be compiled.
 
 > Note: The `dictionary.json` file is ignored by git. This file can be uploaded to Lectern, for example, but it shouldn't appear in this repo.
+
+### Testing your dictionary locally
+
+`node populateReferences.js` will create `populated_dictionary.json`. The output of the script is **not** intended to be uploaded to Lectern. Instead, it is to aid in testing with the [clinical repo](https://github.com/icgc-argo/argo-clinical). It can be used to add/overwrite the contents of the [sample-schema](https://github.com/icgc-argo/argo-clinical/blob/master/sampleFiles/sample-schema.json), when the Lectern URL in the .env file is set to said file's path.

--- a/populateReferences.js
+++ b/populateReferences.js
@@ -1,0 +1,28 @@
+// Tool to aid in testing only
+// populates the references from dictionary.json with the actual references, generates populated_dictionary.json
+// allows for easy overwrite into clinical's sample-schema.json
+const fs = require('fs');
+const dict = require('./dictionary.json');
+
+const old = JSON.stringify(dict);
+
+// References look like this : /#/scripts/donor/ensuredeceased
+// This regex finds them
+const regex = /"#\/.+?(?=\")"/g;
+
+
+const replacer = (match) => {
+    const strip = /#\//;
+    const stripped = match.replace(strip,'').replace(/"/g,'');
+    const refs = stripped.split('\/')
+    let replacement = dict.references;
+    refs.forEach(element => {
+        replacement = replacement[element]
+    });
+    return JSON.stringify(replacement);
+  }
+
+const newString = old.replace(regex, replacer);
+
+fs.writeFileSync('./populated_dictionary.json', newString);
+

--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -1,0 +1,70 @@
+/**
+ * Validates that tumour_grade is a permissable value based on tumour_grading_system
+ * 
+ * @param {Object} $row The object representing the row for a donor. Object keys represent the fields.
+ * @param {String} $field The value for the field.
+ */
+const validation = ($row,$field) => 
+    (function validate() {
+        let result = {valid: true, message: "Ok"};
+
+        switch ($row.tumour_grading_system.trim().toLowerCase()) {
+            case 'default':
+                let codeList = [
+                    'gx - cannot be assessed',
+                    'g1 well differentiated/low grade',
+                    'g2 moderately differentiated/intermediated grade',
+                    'g3 poorly differentiated/high grade',
+                    'g4 undifferentiated/high grade'
+                ];
+                break;
+            case 'gleason':
+                let codeList = [
+                    'gleason X: gleason score cannot be determined',
+                    'gleason 2–6: the tumor tissue is well differentiated',
+                    'gleason 7: the tumor tissue is moderately differentiated',
+                    'gleason 8–10: the tumor tissue is poorly differentiated or undifferentiated'
+                ];
+                break;
+            case 'nottingham':
+                let codeList = [
+                    'g1 (low grade or well differentiated)',
+                    'g2 (intermediate grade or moderately differentiated)',
+                    'g3 (high grade or poorly differentiated)'
+                ];
+                break;
+            case 'brain cancer':
+                let codeList = [
+                    'grade i',
+                    'grade ii',
+                    'grade iii',
+                    'grade iv'
+                ];
+                break;
+            case 'isup for renal cell carcinoma':
+                let codeList = [
+                    'grade 1: tumor cell nucleoli invisible or small and basophilic at 400 x magnification',
+                    'grade 2: tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification',
+                    'grade 3: tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification',
+                    'grade 4: tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation'
+                ];
+                break;
+            case 'lymphoid neoplasms':
+                let codeList = [
+                    'low grade or indolent nhl',
+                    'high grade or aggressive nhl'
+                ];
+                break;
+          }
+
+        if (!codeList.includes($field.trim().toLowerCase())){
+            const msg = `'${field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}',
+            'tumour_grade' must be one of the following: \n ${codeList}`;
+
+            result.valid = false;
+            result.message = msg;
+        }
+        return result;
+    })();
+
+module.exports = validation;

--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -55,9 +55,11 @@ const validation = ($row,$field) =>
                     'high grade or aggressive nhl'
                 ];
                 break;
+            default:
+                codelist = [];
         }
 
-        if (!codeList.includes($field.trim().toLowerCase())){
+        if (!codeList.includes($field.trim().toLowerCase()) && codeList.length){
             const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}','tumour_grade' must be one of the following: \n${codeList.join("\n")}`;
 
             result.valid = false;

--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -7,10 +7,10 @@
 const validation = ($row,$field) => 
     (function validate() {
         let result = {valid: true, message: "Ok"};
-
+        let codeList = [];
         switch ($row.tumour_grading_system.trim().toLowerCase()) {
             case 'default':
-                let codeList = [
+                codeList = [
                     'gx - cannot be assessed',
                     'g1 well differentiated/low grade',
                     'g2 moderately differentiated/intermediated grade',
@@ -19,7 +19,7 @@ const validation = ($row,$field) =>
                 ];
                 break;
             case 'gleason':
-                let codeList = [
+                codeList = [
                     'gleason X: gleason score cannot be determined',
                     'gleason 2–6: the tumor tissue is well differentiated',
                     'gleason 7: the tumor tissue is moderately differentiated',
@@ -27,14 +27,14 @@ const validation = ($row,$field) =>
                 ];
                 break;
             case 'nottingham':
-                let codeList = [
+                codeList = [
                     'g1 (low grade or well differentiated)',
                     'g2 (intermediate grade or moderately differentiated)',
                     'g3 (high grade or poorly differentiated)'
                 ];
                 break;
             case 'brain cancer':
-                let codeList = [
+                codeList = [
                     'grade i',
                     'grade ii',
                     'grade iii',
@@ -42,7 +42,7 @@ const validation = ($row,$field) =>
                 ];
                 break;
             case 'isup for renal cell carcinoma':
-                let codeList = [
+                codeList = [
                     'grade 1: tumor cell nucleoli invisible or small and basophilic at 400 x magnification',
                     'grade 2: tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification',
                     'grade 3: tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification',
@@ -50,7 +50,7 @@ const validation = ($row,$field) =>
                 ];
                 break;
             case 'lymphoid neoplasms':
-                let codeList = [
+                codeList = [
                     'low grade or indolent nhl',
                     'high grade or aggressive nhl'
                 ];
@@ -58,8 +58,7 @@ const validation = ($row,$field) =>
           }
 
         if (!codeList.includes($field.trim().toLowerCase())){
-            const msg = `'${field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}',
-            'tumour_grade' must be one of the following: \n ${codeList}`;
+            const msg = `'${field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}','tumour_grade' must be one of the following: \n${codeList.join("\n")}`;
 
             result.valid = false;
             result.message = msg;
@@ -67,4 +66,12 @@ const validation = ($row,$field) =>
         return result;
     })();
 
+
+const row = {
+    'tumour_grade': 'meats',
+    'tumour_grading_system': 'nottingham'
+}
+const field = row.tumour_grade;
+
+console.log(validation(row,field).message);
 module.exports = validation;

--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -20,7 +20,7 @@ const validation = ($row,$field) =>
                 break;
             case 'gleason':
                 codeList = [
-                    'gleason X: gleason score cannot be determined',
+                    'gleason x: gleason score cannot be determined',
                     'gleason 2–6: the tumor tissue is well differentiated',
                     'gleason 7: the tumor tissue is moderately differentiated',
                     'gleason 8–10: the tumor tissue is poorly differentiated or undifferentiated'
@@ -55,10 +55,10 @@ const validation = ($row,$field) =>
                     'high grade or aggressive nhl'
                 ];
                 break;
-          }
+        }
 
         if (!codeList.includes($field.trim().toLowerCase())){
-            const msg = `'${field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}','tumour_grade' must be one of the following: \n${codeList.join("\n")}`;
+            const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}','tumour_grade' must be one of the following: \n${codeList.join("\n")}`;
 
             result.valid = false;
             result.message = msg;
@@ -66,12 +66,4 @@ const validation = ($row,$field) =>
         return result;
     })();
 
-
-const row = {
-    'tumour_grade': 'meats',
-    'tumour_grading_system': 'nottingham'
-}
-const field = row.tumour_grade;
-
-console.log(validation(row,field).message);
 module.exports = validation;

--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -243,7 +243,7 @@
       },
       "restrictions": {
         "required": true,
-        "script": "function validate() {\r\n  var result = { valid: true, message: \"depends on tumour_grading_system\" };\r\n  return result;\r\n}\r\n\r\nvalidate();"
+        "script": "#/script/specimen/tumourGrade"
       }
     },
     {

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,9 +22,6 @@ Testing files end with `.test.js`
 
 > You can use `.only` or `.skip` on `describe` or `test` blocks to control which subset of tests you want to run.
 
-> You can run the [constructDummyData](constructDummyData.js) script to generate `.json` templates of the schemas with all the field names preloaded to null values. The files sit in the [dummyData folder](/dummyData/).
-
-
 ## Running Tests
 
 ### Running a Single Test

--- a/tests/donor/ensureDeceased.test.js
+++ b/tests/donor/ensureDeceased.test.js
@@ -5,7 +5,7 @@ const loadObjects = require('../loadObjects');
 // load in all fields with entries prepopulated to null
 const donor = require('../constructDummyData').getSchemaDummy('donor');
 
-// the name of the field being validateds
+// the name of the field being validated
 const name = "cause_of_death";
 
 const unitTests = [

--- a/tests/donor/ensureDeceased.test.js
+++ b/tests/donor/ensureDeceased.test.js
@@ -3,10 +3,9 @@ const universalTest = require('../universal');
 const loadObjects = require('../loadObjects');
 
 // load in all fields with entries prepopulated to null
-// const donor = require('../dummyData/donor.json');
 const donor = require('../constructDummyData').getSchemaDummy('donor');
 
-// the name of the field being validated
+// the name of the field being validateds
 const name = "cause_of_death";
 
 const unitTests = [

--- a/tests/loadObjects.js
+++ b/tests/loadObjects.js
@@ -8,7 +8,7 @@ const loadObjects = (dummy, inputs) =>{
     const doesfieldExist = (field) => {
         const doesExist = Object.keys(dummy).includes(field);
         if (!doesExist){
-            throw `the field name : '${field}' did not match the fields from the dummy file: ${JSON.stringify(dummy,null,4)}. 
+            throw `the field name : '${field}' did not match the fields from the dummy schema: ${JSON.stringify(dummy,null,4)}. 
             \nPlease ensure that the '${field}' field exists in the schema, and is spelled correctly.`
         }
         return doesExist;

--- a/tests/specimen/tumourGrade.test.js
+++ b/tests/specimen/tumourGrade.test.js
@@ -1,0 +1,329 @@
+const validation = require('./../../references/validationFunctions/specimen/tumourGrade.js');
+const universalTest = require('../universal');
+const loadObjects = require('../loadObjects');
+
+// load in all fields with entries prepopulated to null
+const specimen = require('../constructDummyData').getSchemaDummy('specimen');
+
+// the name of the field being validateds
+const name = "tumour_grade";
+
+const unitTests = [
+    [
+        'Grading system set to "default", tumour grade is: "Gx - cannot be assessed"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "default",
+                "tumour_grade": "Gx - cannot be assessed"
+            }
+        )
+    ],
+    [
+        'Grading system set to "default", tumour grade is: "G1 well differentiated/low grade"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "default",
+                "tumour_grade": "G1 well differentiated/low grade"
+            }
+        )
+    ],
+    [
+        'Grading system set to "default", tumour grade is: "G2 moderately differentiated/intermediated grade"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "default",
+                "tumour_grade": "G2 moderately differentiated/intermediated grade"
+            }
+        )
+    ],
+    [
+        'Grading system set to "default", tumour grade is: "G3 poorly differentiated/high grade"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Default ",
+                "tumour_grade": "G3 poorly differentiated/high grade"
+            }
+        )
+    ],
+    [
+        'Grading system set to "default", tumour grade is: "G4 undifferentiated/high grade"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": " DefaulT ",
+                "tumour_grade": " G4 undifferentiated/high grade "
+            }
+        )
+    ],
+    [
+        'Grading system set to "default", tumour grade is an impermissable value',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": " DefaulT ",
+                "tumour_grade": " an impermissable VALUE!!! "
+            }
+        )
+    ],
+    [
+        'Grading system set to "Gleason", tumour grade is "Gleason X: Gleason score cannot be determined"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "gleason",
+                "tumour_grade": "Gleason X: Gleason score cannot be determined"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Gleason", tumour grade is "Gleason 2–6: The tumor tissue is well differentiated"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": " gleason ",
+                "tumour_grade": "Gleason 2–6: The tumor tissue is well differentiated"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Gleason", tumour grade is "Gleason 7: The tumor tissue is moderately differentiated"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "gleason",
+                "tumour_grade": "Gleason 7: The tumor tissue is moderately differentiated"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Gleason", tumour grade is "Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "gleason",
+                "tumour_grade": "Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Gleason", tumour grade is a value from another codelist',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "gleason",
+                "tumour_grade": "Grade IV"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Nottingham", tumour grade is "G1 (Low grade or well differentiated)"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "nottingham ",
+                "tumour_grade": "G1 (Low grade or well differentiated)"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Nottingham", tumour grade is "G2 (Intermediate grade or moderately differentiated)"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "nottingham ",
+                "tumour_grade": "G2 (Intermediate grade or moderately differentiated)"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Nottingham", tumour grade is "G3 (High grade or poorly differentiated)"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "nottingham ",
+                "tumour_grade": "G3 (High grade or poorly differentiated)"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Nottingham", tumour grade is just whitespace',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "nottingham ",
+                "tumour_grade": "          "
+            }
+        )
+    ],
+    [
+        'Grading system set to "Brain cancer", tumour grade is "Grade I"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "brain Cancer ",
+                "tumour_grade": "Grade I"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Brain cancer", tumour grade is "Grade II"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "brain Cancer ",
+                "tumour_grade": "Grade II"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Brain cancer", tumour grade is "Grade III"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "brain Cancer ",
+                "tumour_grade": "Grade III"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Brain cancer", tumour grade is "Grade IV"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "brain Cancer ",
+                "tumour_grade": "Grade IV"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Brain cancer", tumour grade is "Grade V"',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "brain Cancer ",
+                "tumour_grade": "Grade V"
+            }
+        )
+    ],
+    [
+        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "ISUP for renal cell carcinoma ",
+                "tumour_grade": "Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification"
+            }
+        )
+    ],
+    [
+        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "ISUP for renal cell carcinoma ",
+                "tumour_grade": "Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification"
+            }
+        )
+    ],
+    [
+        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "ISUP for renal cell carcinoma ",
+                "tumour_grade": " Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnificatioN "
+            }
+        )
+    ],
+    [
+        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "ISUP for renal cell carcinoma ",
+                "tumour_grade": "Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation"
+            }
+        )
+    ],
+    [
+        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is grade 1 but with spelling mistakes',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "ISUP for renal cell carcinoma ",
+                "tumour_grade": "Grade 1: Tumor cell nucleoolli invisible or small and basophililiic at 400 x magnification"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Lymphoid neoplasms", tumour grade is "Low grade or indolent NHL"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Lymphoid neoplasms ",
+                "tumour_grade": "Low grade or indolent NHL"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Lymphoid neoplasms ",
+                "tumour_grade": "High gRade or aggressive NHL"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Lymphoid neoplasms ",
+                "tumour_grade": "High gRade or aggressive NHL"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Lymphoid neoplasms ",
+                "tumour_grade": "High gRade or aggressive NHL"
+            }
+        )
+    ],
+    [
+        'Grading system set to "Lymphoid neoplasms", tumour grade is gibberish',
+        false,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "Lymphoid neoplasms ",
+                "tumour_grade": "gibberish!"
+            }
+        )
+    ],
+    
+];
+
+
+describe("Common Tests",()=>{
+    unitTests.forEach(test=>{
+        const testIndex = 2;
+        const testInputs = test[testIndex];
+        universalTest(validation(testInputs,name,testInputs[name]));
+    })
+})
+
+describe("Unit Tests for Tumour Grade",()=>{
+    test.each(unitTests)('\n Test %# : %s \nExpecting result.valid to be: %s',(description,target,inputs) =>{
+        const scriptOutput = validation(inputs, inputs[name], inputs[inputs.name]);
+        expect(scriptOutput.valid).toBe(target);
+    })
+})

--- a/tests/specimen/tumourGrade.test.js
+++ b/tests/specimen/tumourGrade.test.js
@@ -309,6 +309,16 @@ const unitTests = [
             }
         )
     ],
+    [
+        'Grading system set to an unexpected value, tumour grade is any text',
+        true,
+        loadObjects(specimen,
+            {   
+                "tumour_grading_system": "A possible new entry to the codelist for tumour grading system.",
+                "tumour_grade": "any text here"
+            }
+        )
+    ],
     
 ];
 
@@ -323,7 +333,7 @@ describe("Common Tests",()=>{
 
 describe("Unit Tests for Tumour Grade",()=>{
     test.each(unitTests)('\n Test %# : %s \nExpecting result.valid to be: %s',(description,target,inputs) =>{
-        const scriptOutput = validation(inputs, inputs[name], inputs[inputs.name]);
+        const scriptOutput = validation(inputs, inputs[name]);
         expect(scriptOutput.valid).toBe(target);
     })
 })


### PR DESCRIPTION
## Implemented the following matrix of 'codelists' as a validation function

 For the field `tumour_grade`, select a value based on tumor_grading_system according to this matrix:

Default | Gleason | Nottingham | Brain cancer | ISUP for renal cell carcinoma | Lymphoid neoplasms
-- | -- | -- | -- | -- | --
Gx - cannot be assessed | Gleason X: Gleason score cannot be determined | G1 (Low grade or well differentiated) | Grade I | Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification | Low grade or indolent NHL
G1 well differentiated/low grade | Gleason 2–6: The tumor tissue is well differentiated | G2 (Intermediate grade or moderately differentiated) | Grade II | Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification | High grade or aggressive NHL
G2 moderately differentiated/intermediated grade | Gleason 7: The tumor tissue is moderately differentiated | G3 (High grade or poorly differentiated) | Grade III | Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification |  
G3 poorly differentiated/high grade | Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated |   | Grade IV | Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation |  
G4 undifferentiated/high grade |   |   |   |   |  

### Additional Notes
- Both fields are required fields so any empty value would have been caught beforehand
- The values for tumour_grading_system are restricted to a codelist so it cannot deviate from those set values
- Wrote unit tests
