### PR TITLE
fixed regex for tumour_histological_type, and added link to ICD-O-3 m…

### DIFF
--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -131,14 +131,14 @@
     },
     {
       "name": "tumour_histological_type",
-      "description": "The code to represent the histology (morphology) of neoplasms that is usually obtained from a pathology report, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3).",
+      "description": "The code to represent the histology (morphology) of neoplasms that is usually obtained from a pathology report, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3). Please refer to the guidelines provided in the ICD-O-3 manual at https://apps.who.int/iris/handle/10665/42344.",
       "valueType": "string",
       "meta": {
         "core": true
       },
       "restrictions": {
         "required": true,
-        "regex": "M-[0-9]{4}/[0-9]{2}$"
+        "regex": "^[8,9]{1}[0-9]{3}/[0,1,2,3,6,9]{1}[1-9]{0,1}$"
       }
     },
     {


### PR DESCRIPTION
Fixed regex in `tumour_histological_type` field

***Format of ICD-O-3 morphology code:***
![icd-o-3-morphology-format](https://user-images.githubusercontent.com/4992044/75902157-9d9b2e00-5e0d-11ea-8029-df23702d32f9.png)

**Cell type: is 4 digits and ca range from 8000-9992**

**Behavior: is 1 digit** 
![icd-o-3 behavior](https://user-images.githubusercontent.com/4992044/75902783-945e9100-5e0e-11ea-949f-564a1d2d98cb.png)


**Differentiation: is 1 digit**
![icd-o-3 grade](https://user-images.githubusercontent.com/4992044/75902814-a3ddda00-5e0e-11ea-8405-e8dcf65ae7b5.png)
