### PR TITLE
Remove the required flags for several fields

### DIFF
--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -1,71 +1,68 @@
 /**
  * Validates that tumour_grade is a permissable value based on tumour_grading_system
- * 
+ *
  * @param {Object} $row The object representing the row for a donor. Object keys represent the fields.
  * @param {String} $field The value for the field.
  */
-const validation = ($row,$field) => 
-    (function validate() {
-        let result = {valid: true, message: "Ok"};
-        let codeList = [];
-        switch ($row.tumour_grading_system.trim().toLowerCase()) {
-            case 'default':
-                codeList = [
-                    'gx - cannot be assessed',
-                    'g1 well differentiated/low grade',
-                    'g2 moderately differentiated/intermediated grade',
-                    'g3 poorly differentiated/high grade',
-                    'g4 undifferentiated/high grade'
-                ];
-                break;
-            case 'gleason':
-                codeList = [
-                    'gleason x: gleason score cannot be determined',
-                    'gleason 2–6: the tumor tissue is well differentiated',
-                    'gleason 7: the tumor tissue is moderately differentiated',
-                    'gleason 8–10: the tumor tissue is poorly differentiated or undifferentiated'
-                ];
-                break;
-            case 'nottingham':
-                codeList = [
-                    'g1 (low grade or well differentiated)',
-                    'g2 (intermediate grade or moderately differentiated)',
-                    'g3 (high grade or poorly differentiated)'
-                ];
-                break;
-            case 'brain cancer':
-                codeList = [
-                    'grade i',
-                    'grade ii',
-                    'grade iii',
-                    'grade iv'
-                ];
-                break;
-            case 'isup for renal cell carcinoma':
-                codeList = [
-                    'grade 1: tumor cell nucleoli invisible or small and basophilic at 400 x magnification',
-                    'grade 2: tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification',
-                    'grade 3: tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification',
-                    'grade 4: tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation'
-                ];
-                break;
-            case 'lymphoid neoplasms':
-                codeList = [
-                    'low grade or indolent nhl',
-                    'high grade or aggressive nhl'
-                ];
-                break;
-            default:
-                codelist = [];
-        }
+const validation = ($row, $field) =>
+  (function validate() {
+    let result = { valid: true, message: 'Ok' };
+    if ($row.tumour_grading_system && $field) {
+      let codeList = [];
 
-        if (!codeList.includes($field.trim().toLowerCase()) && codeList.length){
-            const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${$row.tumour_grading_system}', 'tumour_grade' must be one of the following: \n${codeList.join("\n")}`;
+      switch ($row.tumour_grading_system && $row.tumour_grading_system.trim().toLowerCase()) {
+        case 'default':
+          codeList = [
+            'gx - cannot be assessed',
+            'g1 well differentiated/low grade',
+            'g2 moderately differentiated/intermediated grade',
+            'g3 poorly differentiated/high grade',
+            'g4 undifferentiated/high grade',
+          ];
+          break;
+        case 'gleason':
+          codeList = [
+            'gleason x: gleason score cannot be determined',
+            'gleason 2–6: the tumor tissue is well differentiated',
+            'gleason 7: the tumor tissue is moderately differentiated',
+            'gleason 8–10: the tumor tissue is poorly differentiated or undifferentiated',
+          ];
+          break;
+        case 'nottingham':
+          codeList = [
+            'g1 (low grade or well differentiated)',
+            'g2 (intermediate grade or moderately differentiated)',
+            'g3 (high grade or poorly differentiated)',
+          ];
+          break;
+        case 'brain cancer':
+          codeList = ['grade i', 'grade ii', 'grade iii', 'grade iv'];
+          break;
+        case 'isup for renal cell carcinoma':
+          codeList = [
+            'grade 1: tumor cell nucleoli invisible or small and basophilic at 400 x magnification',
+            'grade 2: tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification',
+            'grade 3: tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification',
+            'grade 4: tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation',
+          ];
+          break;
+        case 'lymphoid neoplasms':
+          codeList = ['low grade or indolent nhl', 'high grade or aggressive nhl'];
+          break;
+        default:
+          codelist = [];
+      }
 
-            result.valid = false;
-            result.message = msg;
-        }
-        return result;
-    })();
+      if (!codeList.includes($field.trim().toLowerCase()) && codeList.length) {
+        const msg = `'${$field}' is not a permissible value. When 'tumour_grading_system' is set to '${
+          $row.tumour_grading_system
+        }', 'tumour_grade' must be one of the following: \n${codeList.join('\n')}`;
+
+        result.valid = false;
+        result.message = msg;
+      }
+    }
+    return result;
+  })();
 
 module.exports = validation;

--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -55,7 +55,6 @@
       },
       "restrictions": {
         "script": "#/script/common/ajccValidation",
-        "required": true,
         "codeList": [
           "Binet",
           "Rai",
@@ -111,9 +110,6 @@
       "meta": {
         "core": true,
         "dependsOn": "specimen.pathological_tumour_staging_system"
-      },
-      "restrictions": {
-        "required": true
       }
     },
     {
@@ -212,7 +208,6 @@
         "core": true
       },
       "restrictions": {
-        "required": true,
         "codeList": [
           "Default",
           "Gleason",
@@ -233,7 +228,6 @@
         "notes": "This field depends on the selected tumour grading system."
       },
       "restrictions": {
-        "required": true,
         "script": "#/script/specimen/tumourGrade"
       }
     },
@@ -243,9 +237,6 @@
       "valueType": "number",
       "meta": {
         "core": true
-      },
-      "restrictions": {
-        "required": true
       }
     },
     {
@@ -254,9 +245,6 @@
       "valueType": "number",
       "meta": {
         "core": true
-      },
-      "restrictions": {
-        "required": true
       }
     },
     {
@@ -276,9 +264,6 @@
       "valueType": "number",
       "meta": {
         "core": true
-      },
-      "restrictions": {
-        "required": true
       }
     },
     {
@@ -287,9 +272,6 @@
       "valueType": "number",
       "meta": {
         "core": true
-      },
-      "restrictions": {
-        "required": true
       }
     }
   ]

--- a/tests/specimen/tumourGrade.test.js
+++ b/tests/specimen/tumourGrade.test.js
@@ -6,334 +6,293 @@ const loadObjects = require('../loadObjects');
 const specimen = require('../constructDummyData').getSchemaDummy('specimen');
 
 // the name of the field being validateds
-const name = "tumour_grade";
+const name = 'tumour_grade';
 
 const unitTests = [
-    [
-        'Grading system set to "default", tumour grade is: "Gx - cannot be assessed"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "default",
-                "tumour_grade": "Gx - cannot be assessed"
-            }
-        )
-    ],
-    [
-        'Grading system set to "default", tumour grade is: "G1 well differentiated/low grade"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "default",
-                "tumour_grade": "G1 well differentiated/low grade"
-            }
-        )
-    ],
-    [
-        'Grading system set to "default", tumour grade is: "G2 moderately differentiated/intermediated grade"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "default",
-                "tumour_grade": "G2 moderately differentiated/intermediated grade"
-            }
-        )
-    ],
-    [
-        'Grading system set to "default", tumour grade is: "G3 poorly differentiated/high grade"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Default ",
-                "tumour_grade": "G3 poorly differentiated/high grade"
-            }
-        )
-    ],
-    [
-        'Grading system set to "default", tumour grade is: "G4 undifferentiated/high grade"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": " DefaulT ",
-                "tumour_grade": " G4 undifferentiated/high grade "
-            }
-        )
-    ],
-    [
-        'Grading system set to "default", tumour grade is an impermissable value',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": " DefaulT ",
-                "tumour_grade": " an impermissable VALUE!!! "
-            }
-        )
-    ],
-    [
-        'Grading system set to "Gleason", tumour grade is "Gleason X: Gleason score cannot be determined"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "gleason",
-                "tumour_grade": "Gleason X: Gleason score cannot be determined"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Gleason", tumour grade is "Gleason 2–6: The tumor tissue is well differentiated"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": " gleason ",
-                "tumour_grade": "Gleason 2–6: The tumor tissue is well differentiated"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Gleason", tumour grade is "Gleason 7: The tumor tissue is moderately differentiated"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "gleason",
-                "tumour_grade": "Gleason 7: The tumor tissue is moderately differentiated"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Gleason", tumour grade is "Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "gleason",
-                "tumour_grade": "Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Gleason", tumour grade is a value from another codelist',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "gleason",
-                "tumour_grade": "Grade IV"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Nottingham", tumour grade is "G1 (Low grade or well differentiated)"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "nottingham ",
-                "tumour_grade": "G1 (Low grade or well differentiated)"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Nottingham", tumour grade is "G2 (Intermediate grade or moderately differentiated)"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "nottingham ",
-                "tumour_grade": "G2 (Intermediate grade or moderately differentiated)"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Nottingham", tumour grade is "G3 (High grade or poorly differentiated)"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "nottingham ",
-                "tumour_grade": "G3 (High grade or poorly differentiated)"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Nottingham", tumour grade is just whitespace',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "nottingham ",
-                "tumour_grade": "          "
-            }
-        )
-    ],
-    [
-        'Grading system set to "Brain cancer", tumour grade is "Grade I"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "brain Cancer ",
-                "tumour_grade": "Grade I"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Brain cancer", tumour grade is "Grade II"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "brain Cancer ",
-                "tumour_grade": "Grade II"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Brain cancer", tumour grade is "Grade III"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "brain Cancer ",
-                "tumour_grade": "Grade III"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Brain cancer", tumour grade is "Grade IV"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "brain Cancer ",
-                "tumour_grade": "Grade IV"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Brain cancer", tumour grade is "Grade V"',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "brain Cancer ",
-                "tumour_grade": "Grade V"
-            }
-        )
-    ],
-    [
-        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "ISUP for renal cell carcinoma ",
-                "tumour_grade": "Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification"
-            }
-        )
-    ],
-    [
-        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "ISUP for renal cell carcinoma ",
-                "tumour_grade": "Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification"
-            }
-        )
-    ],
-    [
-        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "ISUP for renal cell carcinoma ",
-                "tumour_grade": " Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnificatioN "
-            }
-        )
-    ],
-    [
-        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "ISUP for renal cell carcinoma ",
-                "tumour_grade": "Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation"
-            }
-        )
-    ],
-    [
-        'Grading system set to "ISUP for renal cell carcinoma", tumour grade is grade 1 but with spelling mistakes',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "ISUP for renal cell carcinoma ",
-                "tumour_grade": "Grade 1: Tumor cell nucleoolli invisible or small and basophililiic at 400 x magnification"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Lymphoid neoplasms", tumour grade is "Low grade or indolent NHL"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Lymphoid neoplasms ",
-                "tumour_grade": "Low grade or indolent NHL"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Lymphoid neoplasms ",
-                "tumour_grade": "High gRade or aggressive NHL"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Lymphoid neoplasms ",
-                "tumour_grade": "High gRade or aggressive NHL"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Lymphoid neoplasms ",
-                "tumour_grade": "High gRade or aggressive NHL"
-            }
-        )
-    ],
-    [
-        'Grading system set to "Lymphoid neoplasms", tumour grade is gibberish',
-        false,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "Lymphoid neoplasms ",
-                "tumour_grade": "gibberish!"
-            }
-        )
-    ],
-    [
-        'Grading system set to an unexpected value, tumour grade is any text',
-        true,
-        loadObjects(specimen,
-            {   
-                "tumour_grading_system": "A possible new entry to the codelist for tumour grading system.",
-                "tumour_grade": "any text here"
-            }
-        )
-    ],
-    
+  [
+    'Grading system set to "default", tumour grade is: "Gx - cannot be assessed"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'default',
+      tumour_grade: 'Gx - cannot be assessed',
+    }),
+  ],
+  [
+    'Grading system set to "default", tumour grade is: "G1 well differentiated/low grade"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'default',
+      tumour_grade: 'G1 well differentiated/low grade',
+    }),
+  ],
+  [
+    'Grading system set to "default", tumour grade is: "G2 moderately differentiated/intermediated grade"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'default',
+      tumour_grade: 'G2 moderately differentiated/intermediated grade',
+    }),
+  ],
+  [
+    'Grading system set to "default", tumour grade is: "G3 poorly differentiated/high grade"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Default ',
+      tumour_grade: 'G3 poorly differentiated/high grade',
+    }),
+  ],
+  [
+    'Grading system set to "default", tumour grade is: "G4 undifferentiated/high grade"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: ' DefaulT ',
+      tumour_grade: ' G4 undifferentiated/high grade ',
+    }),
+  ],
+  [
+    'Grading system set to "default", tumour grade is an impermissable value',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: ' DefaulT ',
+      tumour_grade: ' an impermissable VALUE!!! ',
+    }),
+  ],
+  [
+    'Grading system set to "Gleason", tumour grade is "Gleason X: Gleason score cannot be determined"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'gleason',
+      tumour_grade: 'Gleason X: Gleason score cannot be determined',
+    }),
+  ],
+  [
+    'Grading system set to "Gleason", tumour grade is "Gleason 2–6: The tumor tissue is well differentiated"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: ' gleason ',
+      tumour_grade: 'Gleason 2–6: The tumor tissue is well differentiated',
+    }),
+  ],
+  [
+    'Grading system set to "Gleason", tumour grade is "Gleason 7: The tumor tissue is moderately differentiated"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'gleason',
+      tumour_grade: 'Gleason 7: The tumor tissue is moderately differentiated',
+    }),
+  ],
+  [
+    'Grading system set to "Gleason", tumour grade is "Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'gleason',
+      tumour_grade: 'Gleason 8–10: The tumor tissue is poorly differentiated or undifferentiated',
+    }),
+  ],
+  [
+    'Grading system set to "Gleason", tumour grade is a value from another codelist',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'gleason',
+      tumour_grade: 'Grade IV',
+    }),
+  ],
+  [
+    'Grading system set to "Nottingham", tumour grade is "G1 (Low grade or well differentiated)"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'nottingham ',
+      tumour_grade: 'G1 (Low grade or well differentiated)',
+    }),
+  ],
+  [
+    'Grading system set to "Nottingham", tumour grade is "G2 (Intermediate grade or moderately differentiated)"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'nottingham ',
+      tumour_grade: 'G2 (Intermediate grade or moderately differentiated)',
+    }),
+  ],
+  [
+    'Grading system set to "Nottingham", tumour grade is "G3 (High grade or poorly differentiated)"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'nottingham ',
+      tumour_grade: 'G3 (High grade or poorly differentiated)',
+    }),
+  ],
+  [
+    'Grading system set to "Nottingham", tumour grade is just whitespace',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'nottingham ',
+      tumour_grade: '          ',
+    }),
+  ],
+  [
+    'Grading system set to "Brain cancer", tumour grade is "Grade I"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'brain Cancer ',
+      tumour_grade: 'Grade I',
+    }),
+  ],
+  [
+    'Grading system set to "Brain cancer", tumour grade is "Grade II"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'brain Cancer ',
+      tumour_grade: 'Grade II',
+    }),
+  ],
+  [
+    'Grading system set to "Brain cancer", tumour grade is "Grade III"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'brain Cancer ',
+      tumour_grade: 'Grade III',
+    }),
+  ],
+  [
+    'Grading system set to "Brain cancer", tumour grade is "Grade IV"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'brain Cancer ',
+      tumour_grade: 'Grade IV',
+    }),
+  ],
+  [
+    'Grading system set to "Brain cancer", tumour grade is "Grade V"',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'brain Cancer ',
+      tumour_grade: 'Grade V',
+    }),
+  ],
+  [
+    'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'ISUP for renal cell carcinoma ',
+      tumour_grade:
+        'Grade 1: Tumor cell nucleoli invisible or small and basophilic at 400 x magnification',
+    }),
+  ],
+  [
+    'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'ISUP for renal cell carcinoma ',
+      tumour_grade:
+        'Grade 2: Tumor cell nucleoli conspicuous at 400 x magnification but inconspicuous at 100 x magnification',
+    }),
+  ],
+  [
+    'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnification"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'ISUP for renal cell carcinoma ',
+      tumour_grade:
+        ' Grade 3: Tumor cell nucleoli eosinophilic and clearly visible at 100 x magnificatioN ',
+    }),
+  ],
+  [
+    'Grading system set to "ISUP for renal cell carcinoma", tumour grade is "Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'ISUP for renal cell carcinoma ',
+      tumour_grade:
+        'Grade 4: Tumors showing extreme nuclear pleomorphism and/or containing tumor giant cells and/or the presence of any proportion of tumor showing sarcomatoid and/or rhabdoid dedifferentiation',
+    }),
+  ],
+  [
+    'Grading system set to "ISUP for renal cell carcinoma", tumour grade is grade 1 but with spelling mistakes',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'ISUP for renal cell carcinoma ',
+      tumour_grade:
+        'Grade 1: Tumor cell nucleoolli invisible or small and basophililiic at 400 x magnification',
+    }),
+  ],
+  [
+    'Grading system set to "Lymphoid neoplasms", tumour grade is "Low grade or indolent NHL"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Lymphoid neoplasms ',
+      tumour_grade: 'Low grade or indolent NHL',
+    }),
+  ],
+  [
+    'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Lymphoid neoplasms ',
+      tumour_grade: 'High gRade or aggressive NHL',
+    }),
+  ],
+  [
+    'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Lymphoid neoplasms ',
+      tumour_grade: 'High gRade or aggressive NHL',
+    }),
+  ],
+  [
+    'Grading system set to "Lymphoid neoplasms", tumour grade is "High grade or aggressive NHL"',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Lymphoid neoplasms ',
+      tumour_grade: 'High gRade or aggressive NHL',
+    }),
+  ],
+  [
+    'Grading system set to "Lymphoid neoplasms", tumour grade is gibberish',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Lymphoid neoplasms ',
+      tumour_grade: 'gibberish!',
+    }),
+  ],
+  [
+    'Grading system set to an unexpected value, tumour grade is any text',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'A possible new entry to the codelist for tumour grading system.',
+      tumour_grade: 'any text here',
+    }),
+  ],
+  [
+    'Grading system undefined',
+    true,
+    loadObjects(specimen, {
+      tumour_grade: 'any text here',
+    }),
+  ],
+  [
+    'grade system undefined',
+    true,
+    loadObjects(specimen, {
+      tumour_grading_system: 'default',
+    }),
+  ],
+  ['both undefined', true, specimen],
 ];
 
+describe('Common Tests', () => {
+  unitTests.forEach(test => {
+    const testIndex = 2;
+    const testInputs = test[testIndex];
+    universalTest(validation(testInputs, name, testInputs[name]));
+  });
+});
 
-describe("Common Tests",()=>{
-    unitTests.forEach(test=>{
-        const testIndex = 2;
-        const testInputs = test[testIndex];
-        universalTest(validation(testInputs,name,testInputs[name]));
-    })
-})
-
-describe("Unit Tests for Tumour Grade",()=>{
-    test.each(unitTests)('\n Test %# : %s \nExpecting result.valid to be: %s',(description,target,inputs) =>{
-        const scriptOutput = validation(inputs, inputs[name]);
-        expect(scriptOutput.valid).toBe(target);
-    })
-})
+describe('Unit Tests for Tumour Grade', () => {
+  test.each(unitTests)(
+    '\n Test %# : %s \nExpecting result.valid to be: %s',
+    (description, target, inputs) => {
+      const scriptOutput = validation(inputs, inputs[name]);
+      expect(scriptOutput.valid).toBe(target);
+    },
+  );
+});


### PR DESCRIPTION
Fields in question are (https://github.com/icgc-argo/argo-dictionary/issues/54):
- pathological_tumour_staging_system
- pathological_T_category
- pathological_N_category
- pathological_M_category
- pathological_stage_group
- tumour_grading_system
- tumour_grade
- percent_tumour_cells
- percent_proliferating_cells
- percent_stromal_cells
- percent_necrosis

These fields are not ALWAYS required. They're only required if the corresponding record from sample_registration had `tumour_normal_designation` set to `Tumour`.

Checking for this will be done upon the `Validate Submission` step, not upon the file upload step. This PR is a blocker for https://github.com/icgc-argo/argo-clinical/pull/394

Added an additional field existence check for a validation function which assumed the existence of one of these fields .