### PR TITLE
Regex changes for cancer type code

### DIFF
--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -54,7 +54,7 @@
       },
       "meta": {
         "core": true,
-        "examples": "C41.1,C39.0,C00.543A"
+        "examples": "C41.1,C16.9,C00.543A"
       }
     },
     {

--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -50,7 +50,7 @@
       "description": "The code to represent the cancer type using the WHO ICD-10 code (https://icd.who.int/browse10/2016/en#/) classification.",
       "restrictions": {
         "required": true,
-        "regex": "\\bC[0-9]{2}.[0-9]{0,3}[A-Z]{0,1}$"
+        "regex": "^C[0-9]{2}.[0-9]{0,3}[A-Z]{0,1}$"
       },
       "meta": {
         "core": true,

--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -50,10 +50,11 @@
       "description": "The code to represent the cancer type using the WHO ICD-10 code (https://icd.who.int/browse10/2016/en#/) classification.",
       "restrictions": {
         "required": true,
-        "regex": "[A-Z]{1}[0-9]{2}.[0-9]{0,3}[A-Z]{0,1}$"
+        "regex": "\\bC[0-9]{2}.[0-9]{0,3}[A-Z]{0,1}$"
       },
       "meta": {
-        "core": true
+        "core": true,
+        "examples": "C41.1,C39.0,C00.543A"
       }
     },
     {


### PR DESCRIPTION
Added three examples for the cancer type code field.
 (two real and one exaggerated to demonstrate full regex)


Instead of allowing any letter from A - Z, enforce the code to start with `C`.
https://icd.who.int/browse10/2016/en#/II

This covers all the codes for malignant neoplasms.
(Did not allow `D`, which covers codes for In situ neoplasms, Benign neoplasms, and Neoplasms of uncertain or unknown behaviour).