### PR TITLE
one misplaced display name

### DIFF
--- a/schemas/sample_registration.json
+++ b/schemas/sample_registration.json
@@ -154,12 +154,12 @@
       "meta": {
         "validationDependency": true,
         "primaryId": true,
-        "examples": "hnc_12,CCG_34_94583,BRCA47832-3239"
+        "examples": "hnc_12,CCG_34_94583,BRCA47832-3239",
+        "displayName": "Submitter Sample ID"
       },
       "restrictions": {
         "required": true,
-        "regex": "#/regex/submitter_id",
-        "displayName": "Submitter Sample ID"
+        "regex": "#/regex/submitter_id"
       }
     },
     {


### PR DESCRIPTION
one displayname was in `restricted` not meta and was not caught by review 

fix needed for Release 3 dictionary release