### PR TITLE
updated regex to exclude ARGO IDs (DO, SP, SA, TR, PD, FU)

### DIFF
--- a/references/regex.json
+++ b/references/regex.json
@@ -1,3 +1,3 @@
 {
-  "submitter_id": "^[A-Za-z0-9\\-\\._]{1,64}$"
+  "submitter_id": "\b(?!DO|SP|SA|TR|PD|FU)\b^[A-Za-z0-9\\-\\._]{1,64}$"
 }

--- a/references/regex.json
+++ b/references/regex.json
@@ -1,3 +1,3 @@
 {
-  "submitter_id": "\b(?!DO|SP|SA|TR|PD|FU)\b^[A-Za-z0-9\\-\\._]{1,64}$"
+  "submitter_id": "\b(?!(?i:DO)|(?i:SP)|(?i:SA)|(?i:TR)|(?i:PD)|(?i:FU))\b^[A-Za-z0-9\\-\\._]{1,64}"
 }


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/107