### PR TITLE
updated term 'relapse' in disease_status_at_followup to 'relapse or r…

### DIFF
--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
@@ -19,7 +19,7 @@ const validation = ($row, $field, $name) =>
             result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is of type 'progression'.` }
         }
         else if (!isRequired && ! (!$field || checkforEmpty($field))) {
-            result = {valid: false, message: `'${$name}' cannot be provided ..etc etc` }
+            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_followup' is not of type 'progression'.` }
         }        
         return result;
     })();

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
@@ -11,7 +11,6 @@ const validation = ($row, $field, $name) =>
         const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();
 
         const isRequired = diseaseStatus.match(/(progression)$/);
-        const otherStatus = ["stable", "partial remission", "no evidence of disease", "complete remission"];
 
         // checks for a string just consisting of whitespace
         const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
@@ -19,12 +18,9 @@ const validation = ($row, $field, $name) =>
         if (isRequired && (!$field || checkforEmpty($field))){
             result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is of type 'progression'.` }
         }
-        else if ((otherStatus.includes(diseaseStatus)) && (!$field || checkforEmpty($field))) {
-            result = {value: true, message: "ok"};
-        }
-        else if (!checkforEmpty($field) && (otherStatus.includes(diseaseStatus))) {
-            result = {valid: false, message: `${$name} cannot be provided if the disease status at followup is not relapse or recurrence.`}
-        }
+        else if (!isRequired && ! (!$field || checkforEmpty($field))) {
+            result = {valid: false, message: `'${$name}' cannot be provided ..etc etc` }
+        }        
         return result;
     })();
 

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenProgression.js
@@ -7,11 +7,11 @@
 const validation = ($row, $field, $name) => 
     (function validate() {
         let result = {valid: true, message: "Ok"};
-
         /* required field, cannot be null */
         const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();
 
         const isRequired = diseaseStatus.match(/(progression)$/);
+        const otherStatus = ["stable", "partial remission", "no evidence of disease", "complete remission"];
 
         // checks for a string just consisting of whitespace
         const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
@@ -19,7 +19,12 @@ const validation = ($row, $field, $name) =>
         if (isRequired && (!$field || checkforEmpty($field))){
             result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is of type 'progression'.` }
         }
-
+        else if ((otherStatus.includes(diseaseStatus)) && (!$field || checkforEmpty($field))) {
+            result = {value: true, message: "ok"};
+        }
+        else if (!checkforEmpty($field) && (otherStatus.includes(diseaseStatus))) {
+            result = {valid: false, message: `${$name} cannot be provided if the disease status at followup is not relapse or recurrence.`}
+        }
         return result;
     })();
 

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
@@ -11,13 +11,13 @@ const validation = ($row, $field, $name) =>
         /* required field, cannot be null */
         const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();
 
-        const isRequired = diseaseStatus === "relapse";
+        const isRequired = diseaseStatus === "relapse or recurrence";
 
         // checks for a string just consisting of whitespace
         const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
 
         if (isRequired && (!$field || checkforEmpty($field))){
-            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' set to 'relapse'.` }
+            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' set to 'relapse or recurrence'.` }
         }
 
         return result;

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
@@ -7,7 +7,6 @@
 const validation = ($row, $field, $name) => 
     (function validate() {
         let result = {valid: true, message: "Ok"};
-        const otherStatus = ['stable', 'complete remission', 'partial remission', 'no evidence of disease']
         
         /* required field, cannot be null */
         const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();
@@ -20,11 +19,8 @@ const validation = ($row, $field, $name) =>
         if (isRequired && (!$field || checkforEmpty($field))){
             result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' set to 'relapse or recurrence'.` }
         }
-        else if ((otherStatus.includes(diseaseStatus)) && (!$field || checkforEmpty($field))) {
-            result = {value: true, message: "ok"};
-        }
-        else if (!checkforEmpty($field) && otherStatus.includes(diseaseStatus)) {
-            result = {valid: false, message: `${$name} cannot be provided if the disease status at followup is not relapse or recurrence.`}
+        else if (!isRequired && ! (!$field || checkforEmpty($field))){
+            result = {valid: false, message: `'${$name}' cannot be provided ..etc etc` }
         }
         return result;
     })();

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
@@ -7,7 +7,8 @@
 const validation = ($row, $field, $name) => 
     (function validate() {
         let result = {valid: true, message: "Ok"};
-
+        const otherStatus = ['stable', 'complete remission', 'partial remission', 'no evidence of disease']
+        
         /* required field, cannot be null */
         const diseaseStatus = $row.disease_status_at_followup.trim().toLowerCase();
 
@@ -19,7 +20,12 @@ const validation = ($row, $field, $name) =>
         if (isRequired && (!$field || checkforEmpty($field))){
             result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' set to 'relapse or recurrence'.` }
         }
-
+        else if ((otherStatus.includes(diseaseStatus)) && (!$field || checkforEmpty($field))) {
+            result = {value: true, message: "ok"};
+        }
+        else if (!checkforEmpty($field) && otherStatus.includes(diseaseStatus)) {
+            result = {valid: false, message: `${$name} cannot be provided if the disease status at followup is not relapse or recurrence.`}
+        }
         return result;
     })();
 

--- a/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
+++ b/references/validationFunctions/follow_up/baseScripts/requiredWhenRelapse.js
@@ -17,10 +17,10 @@ const validation = ($row, $field, $name) =>
         const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
 
         if (isRequired && (!$field || checkforEmpty($field))){
-            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' set to 'relapse or recurrence'.` }
+            result = {valid: false, message: `'${$name}' is a required field if 'disease_status_at_followup' is set to 'relapse or recurrence'.` }
         }
         else if (!isRequired && ! (!$field || checkforEmpty($field))){
-            result = {valid: false, message: `'${$name}' cannot be provided ..etc etc` }
+            result = {valid: false, message: `'${$name}' cannot be provided if 'disease_status_at_folloup' is not set to 'relapse or recurrence'.` }
         }
         return result;
     })();

--- a/references/validationFunctions/follow_up/relapse_type.js
+++ b/references/validationFunctions/follow_up/relapse_type.js
@@ -1,0 +1,5 @@
+const requiredWhenRelapse = require('./baseScripts/requiredWhenRelapse');
+
+module.exports = [
+    requiredWhenRelapse
+];

--- a/schemas/follow_up.json
+++ b/schemas/follow_up.json
@@ -74,7 +74,7 @@
           "Loco-regional progression",
           "No evidence of disease",
           "Partial remission",
-          "Relapse",
+          "Relapse or recurrence",
           "Stable"
         ]
       },
@@ -131,12 +131,12 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
         "displayName": "Relapse Type"
       }
     },
     {
-      "description": "If the donor was clinically disease free following primary treatment and then relapse or progression (for liquid tumours) occurred afterwards, then this field will indicate the length of disease free interval, in days.",
+      "description": "If the donor was clinically disease free following primary treatment and then relapse or recurrence or progression (for liquid tumours) occurred afterwards, then this field will indicate the length of disease free interval, in days.",
       "name": "relapse_interval",
       "valueType": "integer",
       "restrictions": {
@@ -146,7 +146,7 @@
         "core": true,
         "units": "days",
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates a progression or relapse value.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates a progression or relapse or recurrence value.",
         "displayName": "Relapse Interval"
       }
     },
@@ -187,7 +187,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence",
         "displayName": "Method Of Progression Status"
       }
     },
@@ -202,7 +202,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
         "displayName": "Anatomic Site Progression or Recurrences"
       }
     },
@@ -232,7 +232,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
         "displayName": "Recurrance Tumour Staging System"
       }
     },

--- a/schemas/follow_up.json
+++ b/schemas/follow_up.json
@@ -126,7 +126,8 @@
           "Local recurrence",
           "Local recurrence and distant metastasis",
           "Progression (liquid tumours)"
-        ]
+        ],
+        "script": "#/script/follow_up/relapse_type"
       },
       "meta": {
         "core": true,

--- a/schemas/follow_up.json
+++ b/schemas/follow_up.json
@@ -132,7 +132,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicatess a state of progression, relapse, or recurrence.",
         "displayName": "Relapse Type"
       }
     },
@@ -147,7 +147,7 @@
         "core": true,
         "units": "days",
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates a progression or relapse or recurrence value.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
         "displayName": "Relapse Interval"
       }
     },
@@ -188,7 +188,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence",
         "displayName": "Method Of Progression Status"
       }
     },
@@ -203,7 +203,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
         "displayName": "Anatomic Site Progression or Recurrences"
       }
     },
@@ -233,7 +233,7 @@
       "meta": {
         "core": true,
         "dependsOn": "follow_up.disease_status_at_followup",
-        "notes": "This field is required to be submitted if disease_status_at_followup indicates progression or relapse or recurrence.",
+        "notes": "This field is required to be submitted if disease_status_at_followup indicates a state of progression, relapse, or recurrence.",
         "displayName": "Recurrance Tumour Staging System"
       }
     },

--- a/tests/follow_up/requiredWhenProgression.test.js
+++ b/tests/follow_up/requiredWhenProgression.test.js
@@ -18,7 +18,7 @@ const myUnitTests = {
             loadObjects(followUp,
                 {   
                     "disease_status_at_followup": "Distant progression",
-                    "method_of_progression_status": "Autopsy"
+                    "method_of_progression_status": "Biopsy"
                 }
             )
         ],
@@ -61,7 +61,7 @@ const myUnitTests = {
         ],
         [
             'Disease status is partial remission, with method of progression',
-            true,
+            false,
             loadObjects(followUp,
                 {   
                     "disease_status_at_followup": "partial remission",
@@ -111,28 +111,7 @@ const myUnitTests = {
                 }
             )
         ]
-    ],
-    'posttherapy_tumour_staging_system': [
-        [
-            'Disease status is distant progression, with provided PTSS',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "Distant progression",
-                    "posttherapy_tumour_staging_system": "Lugano"
-                }
-            )
-        ],
-        [
-            'Disease status is Loco-regional progression, without provided ASPOR',
-            false,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "Loco-regional progression"
-                }
-            )
-        ]
-    ]
+   ]
 }
 
 

--- a/tests/follow_up/requiredWhenProgression.test.js
+++ b/tests/follow_up/requiredWhenProgression.test.js
@@ -89,6 +89,25 @@ const myUnitTests = {
                     "disease_status_at_followup": "Loco-regional progression"
                 }
             )
+        ],
+        [
+            'Disease status is stable, without provided ASPOR',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "stable"
+                }
+            )
+        ],
+        [
+            'Disease status is stable, with provided ASPOR',
+            false,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "stable",
+                    "anatomic_site_progression_or_recurrences": "Jaw"
+                }
+            )
         ]
     ],
     'recurrence_tumour_staging_system': [
@@ -103,14 +122,34 @@ const myUnitTests = {
             )
         ],
         [
-            'Disease status is Loco-regional progression, without provided ASPOR',
+            'Disease status is Loco-regional progression, without provided recurrence_tumour_staging_system',
             false,
             loadObjects(followUp,
                 {   
                     "disease_status_at_followup": "Loco-regional progression"
                 }
             )
+        ],
+        [
+            'Disease status is complete remission, without provided recurrence_tumour_staging_system',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "complete remission"
+                }
+            )
+        ],
+        [
+            'Disease status is complete remission, with provided recurrence_tumour_staging_system',
+            false,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "complete remission",
+                    "recurrence_tumour_staging_system": "FIGO"
+                }
+            )
         ]
+
    ]
 }
 

--- a/tests/follow_up/requiredWhenRelapse.test.js
+++ b/tests/follow_up/requiredWhenRelapse.test.js
@@ -22,7 +22,7 @@ const myUnitTests = {
         ],
         [
             'Disease status is not relapse, with provided relapse interval',
-            true,
+            false,
             loadObjects(followUp,
                 {   
                     "disease_status_at_followup": "partial remission",
@@ -50,7 +50,7 @@ const myUnitTests = {
             )
         ],
         [
-            'Disease status is not progression, and relapse interval is not provided',
+            'Disease status is not relapse or recurrence, and relapse interval is not provided',
             true,
             loadObjects(followUp,
                 {   
@@ -58,15 +58,6 @@ const myUnitTests = {
                 }
             )
         ],
-        [
-            'Disease status is progression, and relapse interval is not provided',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "Distant progression"
-                }
-            )
-        ]
     ],
     'relapse_type': [
         [
@@ -74,18 +65,8 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "relapse_type": "local recurrence"
-                }
-            )
-        ],
-        [
-            'Disease status is loco-regional progression, and relapse type is Progression (liquid tumours)',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "progression",
-                    "relapse_type": "Progression (liquid tumours)"
                 }
             )
         ],
@@ -96,46 +77,6 @@ const myUnitTests = {
                 {   
                     "disease_status_at_followup": "stable",
                     "relapse_type": "Distant recurrence/metastasis"
-                }
-            )
-        ]
-    ],
-    'method_of_progression_status': [
-        [
-            'Disease status is relapse, with provided method of progression',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "relapse or recurrence",
-                    "method_of_progression_status": "Autopsy"
-                }
-            )
-        ],
-        [
-            'Disease status is relapse, without provided method of progression',
-            false,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "relapse or recurrence"
-                }
-            )
-        ],
-        [
-            'Disease status is partial remission, without method of progression',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "partial remission"
-                }
-            )
-        ],
-        [
-            'Disease status is partial remission, with method of progression',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "partial remission",
-                    "method_of_progression_status": "imaging"
                 }
             )
         ]
@@ -169,27 +110,6 @@ const myUnitTests = {
                 {   
                     "disease_status_at_followup": "relapse or recurrence",
                     "recurrence_tumour_staging_system": "Binet"
-                }
-            )
-        ],
-        [
-            'Disease status is relapse, without provided ASPOR',
-            false,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "relapse or recurrence"
-                }
-            )
-        ]
-    ],
-    'posttherapy_tumour_staging_system': [
-        [
-            'Disease status is relapse, with provided PTSS',
-            true,
-            loadObjects(followUp,
-                {   
-                    "disease_status_at_followup": "Relapse or Recurrence",
-                    "posttherapy_tumour_staging_system": "Murphy"
                 }
             )
         ],

--- a/tests/follow_up/requiredWhenRelapse.test.js
+++ b/tests/follow_up/requiredWhenRelapse.test.js
@@ -68,6 +68,38 @@ const myUnitTests = {
             )
         ]
     ],
+    'relapse_type': [
+        [
+            'Disease status is relapse, and relapse type is Local recurrence',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "relapse",
+                    "relapse_type": "local recurrence"
+                }
+            )
+        ],
+        [
+            'Disease status is loco-regional progression, and relapse type is Progression (liquid tumours)',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "progression",
+                    "relapse_type": "Progression (liquid tumours)"
+                }
+            )
+        ],
+        [
+            'Disease status is stable, and relapse type is recurrence',
+            false,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "stable",
+                    "relapse_type": "Distant recurrence/metastasis"
+                }
+            )
+        ]
+    ],
     'method_of_progression_status': [
         [
             'Disease status is relapse, with provided method of progression',

--- a/tests/follow_up/requiredWhenRelapse.test.js
+++ b/tests/follow_up/requiredWhenRelapse.test.js
@@ -79,7 +79,16 @@ const myUnitTests = {
                     "relapse_type": "Distant recurrence/metastasis"
                 }
             )
-        ]
+        ],
+        [
+            'Disease status is complete remission, and relapse type is not provided',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "complete remission",
+                }
+            )
+        ],
     ],
     'anatomic_site_progression_or_recurrences': [
         [
@@ -101,6 +110,25 @@ const myUnitTests = {
                 }
             )
         ],
+        [
+            'Disease status is stable, without provided ASPOR',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "stable"
+                }
+            )
+        ],
+        [
+            'Disease status is stable, with provided ASPOR',
+            false,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "stable",
+                    "anatomic_site_progression_or_recurrences": "Ankle"
+                }
+            )
+        ],
     ],
     'recurrence_tumour_staging_system': [
         [
@@ -114,11 +142,30 @@ const myUnitTests = {
             )
         ],
         [
-            'Disease status is relapse, without provided ASPOR',
+            'Disease status is relapse, without provided RTSS',
             false,
             loadObjects(followUp,
                 {   
                     "disease_status_at_followup": "relapse or recurrence"
+                }
+            )
+        ],
+        [
+            'Disease status is no evidence of disease, without provided RTSS',
+            true,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "no evidence of disease"
+                }
+            )
+        ],
+        [
+            'Disease status is no evidence of disease, without provided RTSS',
+            false,
+            loadObjects(followUp,
+                {   
+                    "disease_status_at_followup": "no evidence of disease",
+                    "recurrence_tumour_staging_system": "Binet"
                 }
             )
         ]

--- a/tests/follow_up/requiredWhenRelapse.test.js
+++ b/tests/follow_up/requiredWhenRelapse.test.js
@@ -15,7 +15,7 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "relapse_interval": "500"
                 }
             )
@@ -35,7 +35,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse"
+                    "disease_status_at_followup": "relapse or recurrence"
                 }
             )
         ],
@@ -44,7 +44,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "relapse_interval" : "      "
                 }
             )
@@ -74,7 +74,7 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "method_of_progression_status": "Autopsy"
                 }
             )
@@ -84,7 +84,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse"
+                    "disease_status_at_followup": "relapse or recurrence"
                 }
             )
         ],
@@ -114,7 +114,7 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "anatomic_site_progression_or_recurrences": "Ankle"
                 }
             )
@@ -124,7 +124,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse"
+                    "disease_status_at_followup": "relapse or recurrence"
                 }
             )
         ],
@@ -135,7 +135,7 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse",
+                    "disease_status_at_followup": "relapse or recurrence",
                     "recurrence_tumour_staging_system": "Binet"
                 }
             )
@@ -145,7 +145,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse"
+                    "disease_status_at_followup": "relapse or recurrence"
                 }
             )
         ]
@@ -156,7 +156,7 @@ const myUnitTests = {
             true,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "Relapse",
+                    "disease_status_at_followup": "Relapse or Recurrence",
                     "posttherapy_tumour_staging_system": "Murphy"
                 }
             )
@@ -166,7 +166,7 @@ const myUnitTests = {
             false,
             loadObjects(followUp,
                 {   
-                    "disease_status_at_followup": "relapse"
+                    "disease_status_at_followup": "relapse or recurrence"
                 }
             )
         ]


### PR DESCRIPTION
…ecurrence' after discussions with WG where it was agreed the two terms are synonymous. Also updated validation script and tests.

Related to: https://github.com/icgc-argo/argo-dictionary/issues/111