### PR TITLE
updated notes section for presenting_symptoms field to indicate that …

### DIFF
--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -232,8 +232,8 @@
       },
       "meta": {
         "displayName": "Presenting Symptoms",
-        "notes": "To include multiple values, separate values with a comma ',' within your file.",
-        "examples": "Anemia,Bloating,Diabetes"
+        "notes": "To include multiple values, separate values with a pipe delimiter '|' within your file.",
+        "examples": "Anemia|Bloating|Diabetes"
       }
     },
     {


### PR DESCRIPTION
…a pipe delimiter should be used instead of a comma to submit multiple values
Related to https://github.com/icgc-argo/argo-dictionary/issues/155