### PR TITLE
updated treatment file to remove treatment types containing +/- chara…

### DIFF
--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -71,19 +71,18 @@
           "Ablation",
           "Bone marrow transplant",
           "Chemotherapy",
-          "Combined chemo+immunotherapy",
-          "Combined chemo+radiation therapy",
-          "Combined chemo-radiotherapy and surgery",
+          "Combined chemotherapy and immunotherapy",
+          "Combined chemotherapy and radiation therapy",
+          "Combined chemotherapy, radiation therapy and surgery",
           "Endoscopic therapy",
           "Hormonal therapy",
           "Immunotherapy",
-          "Monoclonal antibodies (for liquid tumours)",
           "No treatment",
           "Other targeting molecular therapy",
           "Photodynamic therapy",
           "Radiation therapy",
           "Stem cell transplant",
-          "Surgical resection"
+          "Surgery"
         ]
       },
       "meta": {


### PR DESCRIPTION
…cters. Also renamed 'surgical resection' to 'surgery' and removed 'Monoclonal antibodies (for liquid tumours)'
This is related to https://github.com/icgc-argo/argo-dictionary/issues/179