### PR TITLE
Split therapeutic_intent into 2 fields - treatment_intent and treatment_setting. Also r…

### DIFF
--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -186,8 +186,8 @@
         "required": true,
         "codeList": [
           "Adjuvant",
-          "Neoadjuvant",
           "Advanced/Metastatic",
+          "Neoadjuvant",
           "Not applicable"
         ]
       },

--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "treatment_intent",
-      "description": "Indicate the intended disease outcome for which the treatment is given. (Reference: CDISC [NCI code: C124307])",
+      "description": "Indicate the intended disease outcome for which the treatment is given. (Reference: CDISC [NCIt code: C124307])",
       "valueType": "string",
       "restrictions": {
         "required": true,
@@ -180,7 +180,7 @@
     },
     {
       "name": "treatment_setting",
-      "description": "Indicate the treatment setting, which describes the treatment's purpose in relation to the primary treatment. (Reference: CDISC [NCI code: C124308])",
+      "description": "Indicate the treatment setting, which describes the treatment's purpose in relation to the primary treatment. (Reference: CDISC [NCIt code: C124308])",
       "valueType": "string",
       "restrictions": {
         "required": true,

--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -162,28 +162,42 @@
       "meta": { "displayName": "Number Of Cycles" }
     },
     {
-      "name": "therapeutic_intent",
-      "description": "The therapeutic intent, the reason behind the choice of a therapy, of the treatment.",
+      "name": "treatment_intent",
+      "description": "Indicate the treatment's intent, which is the best kind of effect it could be expected to have on the disease.",
       "valueType": "string",
       "restrictions": {
         "required": true,
         "codeList": [
-          "Adjuvant",
-          "Concurrent",
           "Curative",
-          "Neoadjuvant",
-          "Not applicable",
           "Palliative",
           "Unknown"
         ]
       },
       "meta": {
         "core": true,
-        "displayName": "Therapeutic Intent"
+        "displayName": "Treatment Intent"
       }
     },
     {
-      "name": "response_to_therapy",
+      "name": "treatment_setting",
+      "description": "Indicate the treatment setting, which describes the treatment's purpose in relation to the primary treatment.",
+      "valueType": "string",
+      "restrictions": {
+        "required": true,
+        "codeList": [
+          "Adjuvant",
+          "Neoadjuvant",
+          "Advanced/Metastatic",
+          "Not applicable"
+        ]
+      },
+      "meta": {
+        "core": true,
+        "displayName": "Treatment Setting"
+      }
+    },
+    {
+      "name": "response_to_treatment",
       "description": "The donor's response to the applied treatment regimen. (Source: RECIST)",
       "valueType": "string",
       "restrictions": {
@@ -198,11 +212,11 @@
       },
       "meta": {
         "core": true,
-        "displayName": "Response To Therapy"
+        "displayName": "Response To Treatment"
       }
     },
     {
-      "name": "outcome_of_therapy",
+      "name": "outcome_of_treatment",
       "description": "Indicate the donor's outcome of the prescribed treatment.",
       "valueType": "string",
       "restrictions": {
@@ -220,7 +234,7 @@
         ]
       },
       "meta": {
-        "displayName": "Outcome Of Therapy"
+        "displayName": "Outcome Of Treatment"
       }
     },
     {

--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "treatment_intent",
-      "description": "Indicate the treatment's intent, which is the best kind of effect it could be expected to have on the disease.",
+      "description": "Indicate the intended disease outcome for which the treatment is given. (Reference: CDISC [NCI code: C124307])",
       "valueType": "string",
       "restrictions": {
         "required": true,
@@ -180,7 +180,7 @@
     },
     {
       "name": "treatment_setting",
-      "description": "Indicate the treatment setting, which describes the treatment's purpose in relation to the primary treatment.",
+      "description": "Indicate the treatment setting, which describes the treatment's purpose in relation to the primary treatment. (Reference: CDISC [NCI code: C124308])",
       "valueType": "string",
       "restrictions": {
         "required": true,


### PR DESCRIPTION
…eplaced 'therapy' with 'treatment' in response_to_therapy and outcome_of_therapy field names, to keep it consistent with definition and controlled terminology (the word 'treatment' used in definition and controlled terminology).
Related to https://github.com/icgc-argo/argo-dictionary/issues/199