### PR TITLE
removed 'prior_malignancy', 'cancer_type_prior_malignancy', 'age_at_p…

### DIFF
--- a/schemas/donor.json
+++ b/schemas/donor.json
@@ -165,48 +165,6 @@
       }
     },
     {
-      "description": "Prior malignancy affecting donor.",
-      "name": "prior_malignancy",
-      "restrictions": {
-        "codeList": "#/list/yes_no"
-      },
-      "valueType": "string",
-      "meta": {
-        "displayName": "Prior Malignancy",
-        "examples": "C41.1, C16.9, C00.5, D46.9"
-      }
-    },
-    {
-      "description": "The code to represent the cancer type of a prior malignancy using the WHO ICD-10 code (https://icd.who.int/browse10/2019/en) classification.",
-      "name": "cancer_type_prior_malignancy",
-      "restrictions": {
-        "regex": "^[C|D][0-9]{2}(.[0-9]{1,3}[A-Z]{0,1})?$"
-      },
-      "valueType": "string",
-      "meta": {
-        "displayName": "Cancer Type Prior Malignancy"
-      }
-    },
-    {
-      "description": "If donor has history of prior malignancy, indicate age at previous diagnosis, in years.",
-      "name": "age_at_prior_malignancy",
-      "valueType": "integer",
-      "meta": {
-        "displayName": "Age at Prior Malignancy"
-      }
-    },
-    {
-      "description": "If donor has history of prior malignancy, indicate laterality of previous diagnosis. (Codelist reference: NCI CDE: 4122391)",
-      "name": "laterality_of_prior_malignancy",
-      "valueType": "string",
-      "restrictions": {
-        "codeList": ["Bilateral", "Left", "Midline", "Not applicable", "Right", "Unilateral", "Unilateral, side not specified", "Unknown"]
-      },
-      "meta": {
-        "displayName": "Laterality at Prior Malignancy"
-      }
-    },
-    {
       "description": "Indicate the donor's height, in centimeters (cm).",
       "name": "height",
       "valueType": "integer",


### PR DESCRIPTION
…rior_malignancy' and 'laterality_of_prior_malignancy' fields from Donor table. These will be moved to the Comorbidity optional clinical table, since prior malignancies are considered comorbidities.
This is related to https://github.com/icgc-argo/argo-dictionary/issues/220