### PR TITLE
initialize immunotherapy schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ File Schemas are found in `/schemas`
 Variables, such as recurring scripts, regex, or code lists are found in `/references`. These values can be used in the `restrictions` section of a schema by refering to them with this pattern: `#/path/to/value`.
 
 
-Scripts for validating field values fall under `/references/validationFunctions/{schema name}/`. If a validation script is common in many schemas, it can be added under `/references/validationFunctions/common/`. The filename of the script should not contain dashes/dots (ideally be in camelCase). 
+Scripts for validating field values fall under `/references/validationFunctions/{schema name}/`. If a validation script is common in many schemas, it can be added under `/references/validationFunctions/common/`. The filename of the script should not contain dashes/dots (ideally be in camelCase).
 
 
 Example variable usage:
@@ -55,11 +55,11 @@ To run all unit tests, you can use : `npm run test`.
 [More information about unit tests.](/tests/README.md)
 
 ### Compile Whole Dictionary
-1.  Install dependencies via npm. 
+1.  Install dependencies via npm.
 
 `npm ci`
 
-2. Then run the dictionary building script: 
+2. Then run the dictionary building script:
 
 `npm run compile`
 
@@ -74,3 +74,9 @@ If all tests do not pass, the dictionary will not be compiled.
 ### Testing your dictionary locally
 
 `node populateReferences.js` will create `populated_dictionary.json`. The output of the script is **not** intended to be uploaded to Lectern. Instead, it is to aid in testing with the [clinical repo](https://github.com/icgc-argo/argo-clinical). It can be used to add/overwrite the contents of the [sample-schema](https://github.com/icgc-argo/argo-clinical/blob/master/sampleFiles/sample-schema.json), when the Lectern URL in the .env file is set to said file's path.
+
+### Adding new schemas
+When a new schema is added to the dictionary, you must:
+- Add the new schema into `/schemas` directory.
+- Update `/schemas/index.js` to include the new json schema. The sequence in `module.exports` determines the schema sequence in the dictionary.
+- Run `node populateReferences.js` to create `populated_dictionary.json`.

--- a/schemas/immunotherapy.json
+++ b/schemas/immunotherapy.json
@@ -1,0 +1,97 @@
+{
+  "name": "immunotherapy",
+  "description": "The collection of data elements describing the details of an immunotherapy treatment completed by a donor.",
+  "meta": {
+    "parent": "treatment"
+  },
+  "fields": [
+    {
+      "name": "program_id",
+      "valueType": "string",
+      "description": "Unique identifier of the ARGO program.",
+      "meta": {
+        "validationDependency": true,
+        "primaryId": true,
+        "foreignKey": "sample_registration.program_id",
+        "displayName": "Program ID"
+      },
+      "restrictions": {
+        "required": true
+      }
+    },
+    {
+      "name": "submitter_donor_id",
+      "valueType": "string",
+      "description": "Unique identifier of the donor, assigned by the data provider.",
+      "meta": {
+        "validationDependency": true,
+        "primaryId": true,
+        "foreignKey": "sample_registration.submitter_donor_id",
+        "displayName": "Submitter Donor ID"
+      },
+      "restrictions": {
+        "required": true,
+        "regex": "#/regex/submitter_id"
+      }
+    },
+    {
+      "name": "submitter_treatment_id",
+      "valueType": "string",
+      "description": "Unique identifier of the treatment, assigned by the data provider.",
+      "meta": {
+        "validationDependency": true,
+        "primaryId": true,
+        "foreignKey": "treatment.submitter_treatment_id",
+        "displayName": "Submitter Treatment ID"
+      },
+      "restrictions": {
+        "required": true,
+        "regex": "#/regex/submitter_id"
+      }
+    },
+    {
+      "name": "immunotherapy_type",
+      "valueType": "string",
+      "description": "Indicate the type of immunotherapy administered to patient.",
+      "meta": {
+        "displayName": "Immunotherapy Type"
+      },
+      "restrictions": {
+        "codeList": [
+          "Cell-based",
+          "Immune checkpoint inhibitors",
+          "Monoclonal antibodies other than immune checkpoint inhibitors",
+          "Other immunomodulatory substances"          
+        ]
+      }
+    },
+    {
+      "name": "drug_rxnormcui",
+      "description": "The unique RxNormID assigned to the treatment regimen drug.",
+      "valueType": "string",
+      "meta": {
+        "validationDependency": true,
+        "core": true,
+        "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+        "displayName": "RxNormCUI"
+      },
+      "restrictions": {
+        "required": true
+      }
+    },
+    {
+      "name": "drug_name",
+      "description": "Name of agent or drug administered to patient as part of the treatment regimen.",
+      "valueType": "string",
+      "meta": {
+        "validationDependency": true,
+        "core": true,
+        "notes": "This field uses standardized vocabulary from the RxNorm database (https://www.nlm.nih.gov/research/umls/rxnorm), provided by the NIH.\n\nYou can search for RX Norm values through the web interface (https://mor.nlm.nih.gov/RxNav/) or API (https://mor.nlm.nih.gov/download/rxnav/RxNormAPIs.html).\n\nFor example, to find the rxnormcui based on drug name, you can use: https://rxnav.nlm.nih.gov/REST/rxcui.json?name=leucovorin or https://mor.nlm.nih.gov/RxNav/search?searchBy=String&searchTerm=leucovorin",
+        "displayName": "Immunotherapy Drug Name"
+      },
+      "restrictions": {
+        "required": true
+      }
+    }
+  ]
+}

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -27,6 +27,7 @@ const chemotherapy = require('./chemotherapy.json');
 const hormone_therapy = require('./hormone_therapy.json');
 const radiation = require('./radiation.json');
 const follow_up = require('./follow_up.json');
+const immunotherapy = require('./immunotherapy.json');
 
 module.exports = [
   sample_registration,
@@ -38,4 +39,5 @@ module.exports = [
   hormone_therapy,
   radiation,
   follow_up,
+  immunotherapy
 ];

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -38,6 +38,6 @@ module.exports = [
   chemotherapy,
   hormone_therapy,
   radiation,
+  immunotherapy,
   follow_up,
-  immunotherapy
 ];


### PR DESCRIPTION
- question: in the other treatment tables, the RxNorm id is labelled `core`.  Will immunotherapy information aslo be considered core? 
- In the this, all the values started wiht `Immunotherapy`.  This seem redundant for an immunotherapy table, so i removed that, but I can put it back if you think its best @hknahal 