### PR TITLE
revert int-to-number for release

### DIFF
--- a/schemas/donor.json
+++ b/schemas/donor.json
@@ -167,19 +167,19 @@
     {
       "description": "Indicate the donor's height, in centimeters (cm).",
       "name": "height",
-      "valueType": "number",
+      "valueType": "integer",
       "meta": { "displayName": "Height" }
     },
     {
       "description": "Indicate the donor's weight, in kilograms (kg).",
       "name": "weight",
-      "valueType": "number",
+      "valueType": "integer",
       "meta": { "displayName": "Weight" }
     },
     {
       "description": "Indicate the donor's Body Mass Index (BMI) in kg/m².",
       "name": "bmi",
-      "valueType": "number",
+      "valueType": "integer",
       "meta": { "displayName": "BMI" }
     },
     {


### PR DESCRIPTION
- Clinical i blocking this dictionary from begin submitted bc of the `integer` to `number` change.  It is considered a breaking" change. 

@hknahal i'm reverting this to that we can move forward with this release as the other changes in the dictionary are required.  

@joneubank this should be dictionary 80.6 in QA which was a successful migration. 

