### PR TITLE
Added required field lymph_nodes_examined_status, which will allow nu…

### DIFF
--- a/references/validationFunctions/primary_diagnosis/lymphNodesExamined.js
+++ b/references/validationFunctions/primary_diagnosis/lymphNodesExamined.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *  
+ *
+ */
+
+/**
+ * Enforces requirement on number_lymph_nodes_positive and number_lymph_nodes_examined based on whether lymph nodes were examined. 
+ * @param {object} $row 
+ * @param {string} $field 
+ * @param {string} $name 
+ */
+const validation = () => 
+  (function validate(inputs) {
+      const {$row, $name, $field} = inputs;
+      let result = {valid: true, message: "Ok"};
+
+      // checks for a string just consisting of whitespace
+      const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
+      
+      const lymphNodesExaminedStatus = $row.lymph_nodes_examined_status.trim().toLowerCase();
+      const numberLymphNodesExamined = $row.number_lymph_nodes_examined;
+      const numberLymphNodesPositive = $row.number_lymph_nodes_positive;
+           
+      // if lymph nodes were examined and number_lymph_nodes_examined is submitted, it must be a value greater than 0. Otherwise, this field should be 0 or left blank.
+      if (($name === "number_lymph_nodes_examined") && (!(checkforEmpty($field)))) {
+         if (lymphNodesExaminedStatus === "yes") { 
+            if (parseInt($field) <= 0) {
+               result = {
+                 valid: false,
+                 message: `The '${$name}' field must be a value greater than 0 if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+               };
+            }
+         }
+         else if (parseInt($field) > 0) {
+            result = {
+              valid: false,
+              message: `The '${$name}' field must be submitted as 0 or left blank if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+           };
+        }
+     }
+      
+      // If lymph nodes were examined, number_lymph_nodes_positive must be submitted and it must be a value less than or equal to number_lymph_nodes_examined (if it is submitted). Otherwise, this field should not be submitted.
+      else if ($name === "number_lymph_nodes_positive") {
+         if (lymphNodesExaminedStatus === "yes") {
+            if (checkforEmpty($field) || $field == null) {
+               result = {
+                  valid: false,
+                  message: `The '${$name}' field must be submitted if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+               };
+            }
+            else if (parseInt($field) < 0) {
+               result = {
+                  valid: false,
+                  message: `The '${$name}' field must be a value greater than or equal to 0 if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+               };
+            }
+            else if ((!(checkforEmpty(numberLymphNodesExamined)) && ((parseInt($field) > parseInt(numberLymphNodesExamined))))) {
+               result = {
+                  valid: false,
+                  message: `The '${$name}' field must be a value greater than or equal to 'number_lymph_nodes_examined' if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+               };
+            }
+         }
+         else if (!(checkforEmpty($field))) {
+            result = {
+               valid: false,
+               message: `The '${$name}' field should not be submitted if 'lymph_nodes_examined_status' is '${lymphNodesExaminedStatus}'`
+            };
+         }
+     }
+     return result;
+});
+                 
+module.exports = validation;

--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -104,22 +104,48 @@
       }
     },
     {
-      "name": "number_lymph_nodes_positive",
-      "description": "The number of regional lymph nodes reported as being positive for tumour metastases. (Reference: caDSR CDE ID 6113694)",
-      "valueType": "integer",
+      "name": "lymph_nodes_examined_status",
+      "description": "Indicate if lymph nodes were examined for metastases.",
+      "valueType": "string",
       "restrictions": {
-        "required": true
+        "required": true,
+        "codeList": [
+          "Cannot be determined",
+          "No",
+          "No lymph nodes found in resected specimen",
+          "Not applicable",
+          "Yes"
+        ]
       },
       "meta": {
         "core": true,
-        "displayName": "Number Of Lymph Nodes Positive"
+        "displayName": "Lymph Nodes Examined Status"
       }
     },
     {
       "name": "number_lymph_nodes_examined",
       "description": "The total number of lymph nodes tested for the presence of cancer. (Reference: caDSR CDE ID 3)",
       "valueType": "integer",
-      "meta": { "displayName": "Number Of Lymph Nodes Examined" }
+      "restrictions": { "script": "#/script/primary_diagnosis/lymphNodesExamined" },
+      "meta": {
+        "displayName": "Number Of Lymph Nodes Examined",
+        "dependsOn": "primary_diagnosis.lymph_nodes_examined_status"
+       }
+    },
+    {
+      "name": "number_lymph_nodes_positive",
+      "description": "The number of regional lymph nodes reported as being positive for tumour metastases. (Reference: caDSR CDE ID 6113694)",
+      "valueType": "integer",
+      "restrictions": {
+        "required": true,
+        "script": "#/script/primary_diagnosis/lymphNodesExamined"
+      },
+      "meta": {
+        "core": true,
+        "displayName": "Number Of Lymph Nodes Positive",
+        "dependsOn": "primary_diagnosis.lymph_nodes_examined_status",
+        "notes": "This field is only required if 'lymph_nodes_examined_status' is 'Yes'."
+      }
     },
     {
       "name": "clinical_tumour_staging_system",

--- a/tests/primary_diagnosis/lymphNodesExamined.test.js
+++ b/tests/primary_diagnosis/lymphNodesExamined.test.js
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY                           
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES                          
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT                           
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                                
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED                          
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                               
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER                              
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN                         
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *  
+ *
+ */
+
+const validation = require('../../references/validationFunctions/primary_diagnosis/lymphNodesExamined');
+
+const universalTest = require('../universal');
+const loadObjects = require('../loadObjects');
+
+// load in all fields with entries prepopulated to null
+const primary_diagnosis = require('../constructDummyData').getSchemaDummy('primary_diagnosis');
+
+
+// key -> name of field, value -> unit tests
+const myUnitTests = {
+    'number_lymph_nodes_examined': [
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is a value greater than 0',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 35
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is 0',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 0
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is left blank',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is less than 0',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": -77
+                }
+            )
+        ],
+        [
+            'lymph nodes were not examined but number_lymph_nodes_examined is submitted',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Not applicable",
+                    "number_lymph_nodes_examined": 9
+                }
+            )
+        ],
+        [
+            'lymph nodes were not examined and number_lymph_nodes_examined is 0',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Not applicable",
+                    "number_lymph_nodes_examined": 0
+                }
+            )
+        ]
+   ],
+   'number_lymph_nodes_positive': [
+        [
+            'lymph nodes were examined and number_lymph_nodes_positive is 0',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_positive": 0
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_positive is left blank',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined, number_lymph_nodes_examined is 16 and number_lymph_nodes_positive is 10',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 16,
+                    "number_lymph_nodes_positive": 10
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined but number_lymph_nodes_positive is greater than number_lymph_nodes_examined. ',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 12,
+                    "number_lymph_nodes_positive": 18
+                }
+            )
+        ],
+        [
+            'lymph nodes were not examined but number_lymph_nodes_positive is submitted. ',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "No",
+                    "number_lymph_nodes_positive": 5
+                }
+            )
+        ],
+        [
+            'lymph nodes could not be examined but number_lymph_nodes_positive is submitted. ',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Cannot be determined",
+                    "number_lymph_nodes_positive": 7
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined but number_lymph_nodes_positive is not submitted. ',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 23
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_positive is a negative value',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_positive": -8783
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is left blank and number_lymph_nodes_positive is a value greater than 0',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": "",
+                    "number_lymph_nodes_positive": 9
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and both number_lymph_nodes_examined and number_lymph_nodes_positive are negative values',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": -2,
+                    "number_lymph_nodes_positive": -9
+                }
+            )
+        ],
+        [
+            'lymph nodes were examined and number_lymph_nodes_examined is the same as number_lymph_nodes_positive',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Yes",
+                    "number_lymph_nodes_examined": 12,
+                    "number_lymph_nodes_positive": 12
+                }
+            )
+        ]
+    ]
+}
+
+
+describe("Common Tests",()=>{
+    Object.entries(myUnitTests).forEach(field =>{
+        const name = field[0];
+        const unitTests = field[1];
+        unitTests.forEach(test=>{
+            const testIndex = 2;
+            const testInputs = test[testIndex];
+            universalTest(validation()({ $row: testInputs, $name: name, $field: testInputs[name]}));
+        })
+    })
+    
+})
+
+describe("Unit Tests for Lymph Node Fields in Primary Diagnosis",()=>{
+    Object.entries(myUnitTests).forEach(field => {
+        const name = field[0];
+        const unitTests = field[1];
+        describe(`Tests for the ${name} field.`,()=>{
+            test.each(unitTests)('\n Test %# : %s \nExpecting result.valid to be: %s',(description,target,inputs) =>{
+                const scriptOutput = validation()({ $row: inputs, $field: inputs[name], $name: name});
+                expect(scriptOutput.valid).toBe(target);
+            })
+        })
+        
+    })
+    
+})


### PR DESCRIPTION
…mber_lymph_nodes_positive to be empty if lymph nodes were not examined. Also added script validation to check values for number_lymph_nodes_examined and number_lymph_nodes_positive to ensure they make sense.

This related to https://github.com/icgc-argo/argo-dictionary/issues/256