### PR TITLE
added term 'Pipe' to controlled terminology for tobacco_type_field.

### DIFF
--- a/schemas/exposure.json
+++ b/schemas/exposure.json
@@ -69,6 +69,7 @@
           "Cigar",
           "Cigarettes",
           "Electronic cigarettes",
+          "Pipe",
           "Roll-ups",
           "Snuff",
           "Unknown",


### PR DESCRIPTION
In Exposure table
NCIt Definition of Pipe: https://ncithesaurus.nci.nih.gov/ncitbrowser/pages/home.jsf;jsessionid=86C759AA40DE86219BF85DE9776FA8BC

