### PR TITLE
added note to comorbidity_type_code explaining why it is both a requi…

### DIFF
--- a/schemas/comorbidity.json
+++ b/schemas/comorbidity.json
@@ -87,7 +87,8 @@
         "primaryId": true,
         "dependsOn": "comorbidity.prior_malignancy",
         "examples": "E10, C50.1, I11, M06",
-        "displayName": "Comorbidity Type Code"
+        "displayName": "Comorbidity Type Code",
+        "notes": "This field is required because it should have a cancer or non-cancer ICD-10 code. This field is marked 'Conditional' because it depends on the value of the `prior_malignancy` field. Both these fields will need to be consistent. If `prior_malignancy` is `Yes`, then an ICD-10 code related to cancer is expected in this field. If `prior_malignancy` is `No`, then an ICD-10 code related to a non-cancer condition is expected in this field."
       }
     },
     {


### PR DESCRIPTION
…red and conditional field.
Related to https://github.com/icgc-argo/argo-dictionary/issues/319

Included a note for the `comorbidity_type_code` field explaining why this field is both required and conditional.