### PR TITLE
Removed the term 'unknown' from controlled terminology to ensure vita…

### DIFF
--- a/schemas/donor.json
+++ b/schemas/donor.json
@@ -38,7 +38,7 @@
       "description": "Donor's last known state of living or deceased.",
       "name": "vital_status",
       "restrictions": {
-        "codeList": ["Alive", "Deceased", "Unknown"],
+        "codeList": ["Alive", "Deceased"],
         "required": true
       },
       "valueType": "string",


### PR DESCRIPTION
…l_status is consistent with other required fields. The process of granting clinical exceptions will deal with the case of vital_status being unknown (for valid reasons), rather than allowing 'unknown' for a single required field in the ARGO dictionary.

Related to https://github.com/icgc-argo/argo-dictionary/issues/329