### PR TITLE
Changed valueType for 'radiation_therapy_dosage' from integer to numb…

### DIFF
--- a/schemas/radiation.json
+++ b/schemas/radiation.json
@@ -95,7 +95,7 @@
     {
       "name": "radiation_therapy_dosage",
       "description": "Indicate the total dose given in units of Gray (Gy).",
-      "valueType": "integer",
+      "valueType": "number",
       "restrictions": {
         "required": true,
         "range": {


### PR DESCRIPTION
…er to allow cGy to Gy conversion
Related to https://github.com/icgc-argo/argo-dictionary/issues/326

Need to test out on QA to ensure cGy -> Gy converted values are accepted.