### PR TITLE
original terms were excluded so added back in (where applicable).

### DIFF
--- a/schemas/radiation.json
+++ b/schemas/radiation.json
@@ -111,6 +111,7 @@
       "name": "anatomical_site_irradiated",
       "description": "Indicate body region where radiation therapy was administered. (Reference: Cancer Care Ontario)",
       "valueType": "string",
+      "isArray": true,
       "restrictions": {
         "required": true,
         "codeList": [

--- a/schemas/radiation.json
+++ b/schemas/radiation.json
@@ -116,13 +116,17 @@
         "codeList": [
           "Abdomen",
           "Body",
+          "Brain",
           "Chest",
           "Head",
+          "Liver",
           "Lower Limb",
+          "Lung",
           "Neck",
           "Pelvis",
           "Skin",
           "Spine",
+          "Thorax",
           "Upper Limb"
         ]
       },


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/315

Made a mistake and meant to merge original terms with new terms. In some cases, certain terms such as "Head-Neck" from the original terminology were removed since they are separate terms in new list (ie. "Head", "Neck"). 

Changed 'anatomical_site_irradiated' to accept multiple values since it's possible to irradiate multiple body areas (ie. Head and Neck).