### PR TITLE
324 laterality field

### DIFF
--- a/schemas/primary_diagnosis.json
+++ b/schemas/primary_diagnosis.json
@@ -108,6 +108,25 @@
       }
     },
     {
+      "name": "laterality",
+      "description": "For cancer in a paired organ, indicate the side of the body on which the primary tumour or cancer first developed at the time of primary diagnosis. (Reference caDSR 827)",
+      "valueType": "string",
+      "restrictions": {
+        "codeList": [
+          "Bilateral",
+          "Left",
+          "Midline",
+          "Not a paired site",
+          "Right",
+          "Unilateral, side not specified",
+          "Unknown"
+        ]
+      },
+      "meta": {
+        "displayName": "Laterality"
+      }
+    },
+    {
       "name": "lymph_nodes_examined_status",
       "description": "Indicate if lymph nodes were examined for metastases.",
       "valueType": "string",

--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -185,6 +185,21 @@
       }
     },
     {
+      "name": "specimen_laterality",
+      "description": "For cancer in a paired organ, indicate the side on which the specimen was obtained. (Reference caDSR 2007875)",
+      "valueType": "string",
+      "restrictions": {
+        "codeList": [
+          "Left",
+          "Right",
+          "Unknown"
+        ]
+      },
+      "meta": {
+        "displayName": "Specimen Laterality"
+      }
+    },
+    {
       "name": "specimen_processing",
       "description": "Indicate the technique used to process specimen.",
       "valueType": "string",


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/324
Added two optional fields for laterality:
- "laterality" in Primary Diagnosis schema to indicate which side cancer developed at time of primary diagnosis when cancer is in a paired organ (for example, breast or lungs)
- "specimen_laterality" in Specimen schema to indicate which side the specimen was obtained when tumour is in a paired organ.