### PR TITLE
Fixed family_relative_id so it shows as an 'ID' rather than 'Extended…

### DIFF
--- a/schemas/family_history.json
+++ b/schemas/family_history.json
@@ -40,6 +40,7 @@
       "valueType": "string",
       "meta": {
         "displayName": "Family Relative ID",
+        "primaryId": true,
         "notes": "This field is required to ensure that family members are identified in unique records.  Ids can be as simple as an incremented numeral to ensure uniqueness."
       },
       "restrictions": {


### PR DESCRIPTION
…' in dictionary viewer
Related to https://github.com/icgc-argo/argo-dictionary/issues/350