### PR TITLE
added meta:core to surgery_type, surgery_site and surgery_location so…

### DIFF
--- a/schemas/surgery.json
+++ b/schemas/surgery.json
@@ -69,6 +69,7 @@
       "valueType": "string",
       "description": "Indicate the type of surgical procedure that was performed. (References: SNOMED, NCIt, UMLS)",
       "meta": {
+        "core": true,
         "displayName": "Surgery Type "
       },
       "restrictions": {
@@ -82,6 +83,7 @@
       "description": "Indicate the ICD-O-3 topography code for the anatomic site where the surgical procedure was performed, according to the International Classification of Diseases for Oncology, 3rd Edition (WHO ICD-O-3).",
       "meta": {
         "displayName": "Surgery Site",
+        "core": true,
         "dependsOn": "surgery.submitter_specimen_id",
         "notes": "Refer to the ICD-O-3 manual for guidelines at https://apps.who.int/iris/handle/10665/42344. This field is not required if a specimen was resected during surgery (ie. if `submitter_specimen_id` is submitted) since anatomic site is collected in the Specimen table."
       },
@@ -96,6 +98,7 @@
       "description": "Indicate whether the surgical procedure was done at the primary, local recurrence or metastatic location.",
       "meta": {
         "displayName": "Surgery Location",
+        "core": true,
         "dependsOn": "surgery.submitter_specimen_id",
         "notes": "This field is not required if a specimen was resected during surgery (ie. if `submitter_specimen_id` is submitted) since type of specimen is collected in the Specimen table."
       },


### PR DESCRIPTION
… they show correctly in dictionary viewer.

The 'surgery_type', 'surgery_site' and 'surgery_location' fields were showing as "Extended" in the Dictionary Viewer because they are missing the "meta: core" flag, but these fields are required and are supposed to be core:

![surgery_fields](https://user-images.githubusercontent.com/4992044/173660948-24a349f5-9db4-4f40-86b6-1a0b86e3098e.png)

After adding "meta:core", the fields show correctly in Dictionary Viewer. This change is in the "meta" section so it does not affect validation, it only affects how the dictionary looks like in the viewer (see [here](https://wiki.oicr.on.ca/pages/viewpage.action?pageId=134938807#DictionaryViewer&DictionarySchemas-SchemasgeneratedthroughLectern) for details on how "meta" field is used)

![surgery_core](https://user-images.githubusercontent.com/4992044/173661173-99091611-6fc7-4a23-b829-b131abd9fbea.png)


