### PR TITLE
Fix lymph nodes examined method script

### DIFF
--- a/references/validationFunctions/primary_diagnosis/lymphNodesExaminedMethod.js
+++ b/references/validationFunctions/primary_diagnosis/lymphNodesExaminedMethod.js
@@ -30,21 +30,25 @@ const validation = () =>
       let result = {valid: true, message: "Ok"};
 
       const notExamined = ['cannot be determined', 'no', 'no lymph nodes found in resected specimen', 'not applicable'];
-      const lymphNodesExaminedStatus = $row.lymph_nodes_examined_status.trim().toLowerCase();
-      
       /* checks for a string just consisting of whitespace */
       const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
       
-      
-      if (!$field || $field === null || checkforEmpty($field)) {
-        if (lymphNodesExaminedStatus === 'yes') {
-          result = { valid: false, message: `The '${$name}' field must be submitted if the 'lymph_nodes_examined_status' field is 'Yes'`};
-        }
+      if ($row.lymph_nodes_examined_status === null) {
+        result = {valid: false, message: `The 'lymph_nodes_examined_status' field must be submitted.`};
       }
       else {
-         if (notExamined.includes(lymphNodesExaminedStatus)) {
-           result = { valid: false, message: `The '${$name}' field should not be submitted if the 'lymph_nodes_examined_status' field is '${lymphNodesExaminedStatus}'`};
-         }
+        const lymphNodesExaminedStatus = $row.lymph_nodes_examined_status.trim().toLowerCase();
+      
+        if (!$field || $field === null || checkforEmpty($field)) {
+          if (lymphNodesExaminedStatus === 'yes') {
+            result = { valid: false, message: `The '${$name}' field must be submitted if the 'lymph_nodes_examined_status' field is 'Yes'`};
+          }
+        }
+        else {
+          if (notExamined.includes(lymphNodesExaminedStatus)) {
+            result = { valid: false, message: `The '${$name}' field should not be submitted if the 'lymph_nodes_examined_status' field is '${lymphNodesExaminedStatus}'`};
+          }
+        }
       }
     return result;
 });

--- a/tests/primary_diagnosis/lymphNodesExaminedMethod.test.js
+++ b/tests/primary_diagnosis/lymphNodesExaminedMethod.test.js
@@ -77,7 +77,16 @@ const myUnitTests = {
                     "lymph_nodes_examined_status": "Not applicable"
                 }
             )
+        ],
+        [
+            'lymph_nodes_examined_status is missing and lymph_nodes_examined_method not submitted',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                }
+            )
         ]
+
     ]
 }
 


### PR DESCRIPTION
- Updated validation script for 'lymph_nodes_examined_method' to check for missing required 'lymph_nodes_examined_status' field. This was causing issues during dictionary migration when an existing clinical submission didn't have either the 'lymph_nodes_examined_status' or 'lymph_nodes_examined_method' fields (the 'lymph_nodes_examined_method' field is dependent on 'lymph_nodes_examined_status' field). As a result, the validation script failed to run because it detected 'lymph_nodes_examined_status' as null. 
- Updated unit tests as well to check for this.