### PR TITLE
Exceptions validation script changes

### DIFF
--- a/references/validationFunctions/primary_diagnosis/lymphNodesExaminedMethod.js
+++ b/references/validationFunctions/primary_diagnosis/lymphNodesExaminedMethod.js
@@ -29,7 +29,7 @@ const validation = () =>
       const {$row, $name, $field} = inputs;
       let result = {valid: true, message: "Ok"};
 
-      const notExamined = ['cannot be determined', 'no', 'no lymph nodes found in resected specimen', 'not applicable'];
+      const notExamined = ['cannot be determined', 'no', 'no lymph nodes found in resected specimen', 'not applicable', 'unknown'];
       /* checks for a string just consisting of whitespace */
       const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
       

--- a/references/validationFunctions/specimen/tumourGrade.js
+++ b/references/validationFunctions/specimen/tumourGrade.js
@@ -95,6 +95,12 @@ const validation = () =>
         case 'nuclear grading system for dcis':
           codeList = tieredGradingList;
           break;
+        case 'unknown':
+          codeList = ['unknown'];
+          break;
+        case 'not applicable':
+          codeList = ['not applicable'];
+          break;
       }
 
       if (!codeList.includes($field.trim().toLowerCase())) {

--- a/tests/primary_diagnosis/lymphNodesExaminedMethod.test.js
+++ b/tests/primary_diagnosis/lymphNodesExaminedMethod.test.js
@@ -61,6 +61,26 @@ const myUnitTests = {
             )
         ],
         [
+            'lymph nodes examined status is unknown and lymph_nodes_examined_method is left blank',
+            true,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Unknown",
+                    "lymph_nodes_examined_method": ""
+                }
+            )
+        ],
+        [
+            'lymph nodes examined status is unknown and lymph_nodes_examined_method is submitted',
+            false,
+            loadObjects(primary_diagnosis,
+                {   
+                    "lymph_nodes_examined_status": "Unknown",
+                    "lymph_nodes_examined_method": "Imaging"
+                }
+            )
+        ],
+        [
             'lymph nodes were examined and lymph_nodes_examined_method not submitted',
             false,
             loadObjects(primary_diagnosis,

--- a/tests/specimen/tumourGrade.test.js
+++ b/tests/specimen/tumourGrade.test.js
@@ -203,6 +203,22 @@ const unitTests = [
       tumour_grade: 'g4'
     }),
   ],
+  [
+    'tumour_grading_system has an exception value of "not applicable", while tumour_grade is submitted as "G3"',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'Not applicable',
+      tumour_grade: 'G3',
+    }),
+  ],
+  [
+    'tumour_grading_system has an exception value of "unknown", while tumour_grade is submitted as "G2"',
+    false,
+    loadObjects(specimen, {
+      tumour_grading_system: 'unknown',
+      tumour_grade: 'G2',
+    }),
+  ],
  // [
  //   'both grade system and grade are undefined',
  //   false,


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/407

Updated validation scripts for fields that are conditional on fields that could have exception values ("not applicable" or "unknown").

### Summary
Updated validation script for `lymph_nodes_examined_method`:
- If `lymph_nodes_examined_status` has an exception value of either `Not applicable` or `Unknown`, then `lymph_nodes_examined_method` is not allowed to be one of the enum values in the dictionary. It must also be either `Not applicable` or `Unknown`.

Updated validation script for `tumour_grade`:
- When`tumour_grading_system` has an exception value of either `Not applicable` or `Unknown`, the error message was not clear. Updated validation script to indicate accepted values if `tumour_grading_system` has an exception value (ie. if `tumour_grading_system` = `Not applicable`, then `tumour_grade` can only be `Not applicable`).