### PR TITLE
409 chemo dose exception

### DIFF
--- a/references/validationFunctions/chemotherapy/drugDose.js
+++ b/references/validationFunctions/chemotherapy/drugDose.js
@@ -33,12 +33,23 @@ const validation = () =>
 
       // checks for a string just consisting of whitespace
       const checkforEmpty = (entry) => {return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'))};
-      
-      if ( (!$field || $field === null || checkforEmpty($field)) && (!($row[checkField]) || $row[checkField] === null || checkforEmpty(!($row[checkField])))) {
-        result = {
-          valid: false,
-          message: `Either the 'actual_cumulative_drug_dose' or the 'prescribed_cumulative_drug_dose' fields must be submitted.`
-        };
+   
+      // Check for when chemotherapy dose has a clinical exception value of 'not applicable'
+      if ($row.chemotherapy_drug_dose_units && $row.chemotherapy_drug_dose_units != null && !(checkforEmpty($row.chemotherapy_drug_dose_units)) && $row.chemotherapy_drug_dose_units.trim().toLowerCase() === 'not applicable') {
+        if ($field && $field != null && !(checkforEmpty($field))) {
+          result = {
+            valid: false,
+            message: `The '${$name}' field cannot be submitted when 'chemotherapy_drug_dose_units' = 'Not applicable'`
+          };
+        }
+      }
+      else {
+        if ( (!$field || $field === null || checkforEmpty($field)) && (!($row[checkField]) || $row[checkField] === null || checkforEmpty(!($row[checkField])))) {
+          result = {
+            valid: false,
+            message: `Either the 'actual_cumulative_drug_dose' or the 'prescribed_cumulative_drug_dose' fields must be submitted.`
+          };
+        }
       }
       return result;
   });

--- a/schemas/chemotherapy.json
+++ b/schemas/chemotherapy.json
@@ -103,6 +103,7 @@
       "meta": {
         "core": true,
         "displayName": "Prescribed Cumulative Drug Dose",
+        "validationDependency": true,
         "dependsOn": "chemotherapy.actual_cumulative_drug_dose",
         "notes": "Either the 'actual_cumulative_drug_dose' or the 'prescribed_cumulative_drug_dose' field must be submitted."
       }
@@ -120,6 +121,7 @@
       "meta": {
         "core": true,
         "displayName": "Actual Cumulative Drug Dose",
+        "validationDependency": true,
         "dependsOn": "chemotherapy.prescribed_cumulative_drug_dose",
         "notes": "Either the 'actual_cumulative_drug_dose' or the 'prescribed_cumulative_drug_dose' field must be submitted."
       }

--- a/tests/chemotherapy/drugDose.test.js
+++ b/tests/chemotherapy/drugDose.test.js
@@ -57,6 +57,25 @@ const myUnitTests = {
                     "prescribed_cumulative_drug_dose": 350
                 }
             )
+        ],
+        [
+            'chemotherapy_drug_dose_units is not applicable and actual_cumulative_drug_dose is submitted',
+            false,
+            loadObjects(chemotherapy,
+                {   
+                    "chemotherapy_drug_dose_units": 'not applicable',
+                    "actual_cumulative_drug_dose": 300,
+                }
+            )
+        ],
+        [
+            'chemotherapy_drug_dose_units is not applicable and actual_cumulative_drug_dose is not submitted',
+            true,
+            loadObjects(chemotherapy,
+                {   
+                    "chemotherapy_drug_dose_units": 'not applicable'
+                }
+            )
         ]
     ],
     'prescribed_cumulative_drug_dose': [
@@ -85,6 +104,25 @@ const myUnitTests = {
                 {   
                     "actual_cumulative_drug_dose": 300,
                     "prescribed_cumulative_drug_dose": 350
+                }
+            )
+        ],
+        [
+            'chemotherapy_drug_dose_units is not applicable and prescribed_cumulative_drug_dose is submitted',
+            false,
+            loadObjects(chemotherapy,
+                {   
+                    "chemotherapy_drug_dose_units": 'not applicable',
+                    "prescribed_cumulative_drug_dose": 350
+                }
+            )
+        ],
+        [
+            'chemotherapy_drug_dose_units is not applicable and prescribed_cumulative_drug_dose is not submitted',
+            true,
+            loadObjects(chemotherapy,
+                {   
+                    "chemotherapy_drug_dose_units": 'not applicable'
                 }
             )
         ],


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/409

- Updated drugDose validation script to check that the prescribed/actual drug dose fields are not submitted when the 'chemotherapy_drug_dose_units' has an exception value of 'Not applicable'.

To test:
- Upload program exceptions file for 'chemotherapy_drug_dose_units' = 'Not applicable'
- Submit chemotherapy table where 'chemotherapy_drug_dose_units' = 'Not applicable'
--> If  'prescribed_cumulative_drug_dose' and/or 'actual_cumulative_drug_dose' fields are submitted, then validation should fail.
--> If  'prescribed_cumulative_drug_dose' and/or 'actual_cumulative_drug_dose' fields are not submitted (left empty), then validation should pass