### PR TITLE
Added two new terms ('Cell line - derived from metastatic tumour' and  'Xenograft - derived from metastatic tumour') to 'specimen_type' codelist

### DIFF
--- a/schemas/sample_registration.json
+++ b/schemas/sample_registration.json
@@ -123,6 +123,7 @@
       "restrictions": {
         "required": true,
         "codeList": [
+          "Cell line - derived from metastatic tumour",
           "Cell line - derived from normal",
           "Cell line - derived from tumour",
           "Cell line - derived from xenograft tumour",
@@ -137,6 +138,7 @@
           "Primary tumour",
           "Recurrent tumour",
           "Tumour - unknown if derived from primary or metastatic",
+          "Xenograft - derived from metastatic tumour",
           "Xenograft - derived from primary tumour",
           "Xenograft - derived from tumour cell line"
         ],


### PR DESCRIPTION
Related to https://github.com/icgc-argo/argo-dictionary/issues/392
SONG update was already done (https://github.com/overture-stack/SONG/issues/790), so just need to add new terms to dictionary