### PR TITLE
remove retriction to accept negative numbers as well

### DIFF
--- a/schemas/specimen.json
+++ b/schemas/specimen.json
@@ -150,10 +150,7 @@
         "displayName": "Specimen Acquisition Interval"
       },
       "restrictions": {
-        "required": true,
-        "range": {
-          "min": 0
-        }
+        "required": true
       }
     },
     {


### PR DESCRIPTION
Related to #432 

Test cases in QA:
- Dictionary version: `130.2`
- Program: MONSTAR-JP, using the following `specimen` file. It contains specimens which have negative `specimen_acquisition_interval`. 
 
[specimen_v1.17.txt](https://github.com/user-attachments/files/16253496/specimen_v1.17.txt)(change `.txt` to `.tsv` when submission)




