### PR TITLE
fix the script to treat the value 0 not as falsy values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,37 +1,39 @@
 {
-  "name": "dictionary",
-  "version": "1.0.0",
-  "description": "Working space for the ARGO Data Dictionary collaboration",
-  "main": "index.js",
-  "scripts": {
-    "compile": "jest && node compile.js && npm run references",
-    "test": "jest",
-    "references": "node populateReferences.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/icgc-argo/argo-dictionary.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/icgc-argo/argo-dictionary/issues"
-  },
-  "homepage": "https://github.com/icgc-argo/argo-dictionary#readme",
-  "dependencies": {},
-  "devDependencies": {
-    "auto-load": "^3.0.4",
-    "chalk": "^3.0.0",
-    "inquirer": "^7.0.1",
-    "jest": "^25.2.3",
-    "json-beautify": "^1.1.1",
-    "prettier": "^1.19.1",
-    "querystring": "^0.2.0",
-    "yargs": "^15.0.2"
-  },
-  "prettier": {
-    "printWidth": 100,
-    "trailingComma": "all",
-    "singleQuote": true
-  }
+	"name": "dictionary",
+	"version": "1.0.0",
+	"description": "Working space for the ARGO Data Dictionary collaboration",
+	"main": "index.js",
+	"scripts": {
+		"compile": "jest && node compile.js && npm run references",
+		"test": "jest",
+		"references": "node populateReferences.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/icgc-argo/argo-dictionary.git"
+	},
+	"author": "",
+	"license": "ISC",
+	"bugs": {
+		"url": "https://github.com/icgc-argo/argo-dictionary/issues"
+	},
+	"homepage": "https://github.com/icgc-argo/argo-dictionary#readme",
+	"devDependencies": {
+		"auto-load": "^3.0.4",
+		"chalk": "^3.0.0",
+		"inquirer": "^7.0.1",
+		"jest": "^25.2.3",
+		"json-beautify": "^1.1.1",
+		"prettier": "^1.19.1",
+		"querystring": "^0.2.0",
+		"yargs": "^15.0.2"
+	},
+	"prettier": {
+		"printWidth": 120,
+		"trailingComma": "all",
+		"semi": true,
+		"singleQuote": true,
+		"tabWidth": 4,
+		"useTabs": true
+	}
 }

--- a/references/validationFunctions/treatment/checkWhenNoTreatment.js
+++ b/references/validationFunctions/treatment/checkWhenNoTreatment.js
@@ -45,10 +45,16 @@ const validation = () =>
 
         const treatmentExceptionTypes = ['no treatment', 'unknown'];
 
-        // checks for a string just consisting of whitespace
-        const checkforEmpty = entry => {
-            return /^\s+$/g.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'));
+        // checks for empty fields
+        const checkforEmpty = (entry) => {
+            // Check if entry is null or undefined
+            if (entry === null || entry === undefined) {
+              return true;
+            } 
+            // Logic to check if the entry is an empty string or contains only whitespace
+            return /^\s*$/.test(decodeURI(entry).replace(/^"(.*)"$/, '$1'));
         };
+
         const treatmentTypes = $row.treatment_type.map(value => value.toLowerCase());
 
         const recordHasTreatments = !arrayItemsInSecondArray(
@@ -58,8 +64,8 @@ const validation = () =>
 
         if (recordHasTreatments) {
             if (
-                coreFields.includes($name) &&
-                (!$field || $field === null || checkforEmpty($field))
+                coreFields.includes($name) && checkforEmpty($field)
+                // ($field === null || $field === undefined || checkforEmpty($field))
             ) {
                 return {
                     valid: false,
@@ -67,7 +73,7 @@ const validation = () =>
                 };
             }
 
-        } else if ($field && $field != null && !checkforEmpty($field)) {
+        } else if (!checkforEmpty($field)) {
             if (
                 coreFields.includes($name) ||
                 (typeof $field === 'string' && $field.trim().toLowerCase() != 'not applicable') ||

--- a/tests/treatment/checkWhenNoTreatment.test.js
+++ b/tests/treatment/checkWhenNoTreatment.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2024 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
  * You should have received a copy of the GNU Affero General Public License along with
@@ -28,444 +28,455 @@ const treatment = require('../constructDummyData').getSchemaDummy('treatment');
 
 // key -> name of field, value -> unit tests
 const myUnitTests = {
-    treatment_start_interval: [
-        [
-            'treatment_start_interval is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_start_interval: 409,
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'treatment_start_interval is missing when treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'treatment_start_interval is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_start_interval: 30,
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_start_interval is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                treatment_start_interval: 0,
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'treatment_start_interval is missing when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_start_interval is missing when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'treatment_start_interval is submitted to be 0 when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_start_interval: 0,
-                treatment_type: ['Chemotherapy'],
-            }),
-      ],
-    ],
-    treatment_duration: [
-        [
-            'treatment_duration is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_duration: 40,
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'treatment_duration is missing when treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'treatment_duration is missing when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_duration is missing when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'treatment_duration is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_duration: 30,
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_duration is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                treatment_duration: 30,
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    is_primary_treatment: [
-        [
-            'is_primary_treatment is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                is_primary_treatment: 'No',
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'is_primary_treatment is missing  when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'is_primary_treatment is missing  when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'is_primary_treatment is empty when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                is_primary_treatment: '',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'is_primary_treatment is empty when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                is_primary_treatment: '',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'is_primary_treatment is missing when treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'is_primary_treatment is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                is_primary_treatment: 'Yes',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'is_primary_treatment is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                is_primary_treatment: 'Yes',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    treatment_setting: [
-        [
-            'treatment_setting is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_setting: 'adjuvant',
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'treatment_setting is missing when treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'treatment_setting is missing when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['no treatment'],
-            }),
-        ],
-        [
-            'treatment_setting is missing when treatment was unknowm',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'treatment_setting is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_setting: 'neoadjuvant',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_setting is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                treatment_setting: 'neoadjuvant',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    treatment_intent: [
-        [
-            'treatment_intent is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_intent: 'palliative',
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'treatment_intent is missing when treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'treatment_intent is not submitted when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_intent is not submitted when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'treatment_intent is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_intent: 'curative',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'treatment_intent is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                treatment_intent: 'curative',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    days_per_cycle: [
-        [
-            'days per cycle is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                days_per_cycle: 12,
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'days per cycle is missing when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'days per cycle is missing when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'days per cycle is missing when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'days per cycle is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                days_per_cycle: 10,
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'days per cycle is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                days_per_cycle: 10,
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    outcome_of_treatment: [
-        [
-            'outcome_of_treatment is submitted when treatment was given',
-            true,
-            loadObjects(treatment, {
-                outcome_of_treatment: 'treatment completed as prescribed',
-                treatment_type: ['Chemotherapy'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is missing when treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Surgery'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is not applicable when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                outcome_of_treatment: 'Not Applicable',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is not applicable when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                outcome_of_treatment: 'Not Applicable',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is empty when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                outcome_of_treatment: '',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is empty when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                outcome_of_treatment: '',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is missing when no treatment was given',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is missing when treatment was unknown',
-            true,
-            loadObjects(treatment, {
-                treatment_type: ['Unknown'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                outcome_of_treatment: 'treatment completed as prescribed',
-                treatment_type: ['No treatment'],
-            }),
-        ],
-        [
-            'outcome_of_treatment is submitted when treatment was unknown',
-            false,
-            loadObjects(treatment, {
-                outcome_of_treatment: 'treatment completed as prescribed',
-                treatment_type: ['Unknown'],
-            }),
-        ],
-    ],
-    response_to_treatment_criteria_method: [
-        [
-            'response_to_treatment_criteria_method is submitted when no treatment was given',
-            false,
-            loadObjects(treatment, {
-                response_to_treatment_criteria_method: 'RECIST',
-                treatment_type: ['no treatment'],
-            }),
-        ],
-        [
-            'response_to_treatment_criteria_method is missing when radiation treatment was given',
-            false,
-            loadObjects(treatment, {
-                treatment_type: ['radiation therapy'],
-            }),
-        ],
-    ],
+	treatment_start_interval: [
+		[
+			'treatment_start_interval is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_start_interval: 409,
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'treatment_start_interval is missing when treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'treatment_start_interval is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_start_interval: 30,
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_start_interval is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				treatment_start_interval: 0,
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'treatment_start_interval is missing when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_start_interval is missing when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'treatment_start_interval is submitted to be 0 when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_start_interval: 0,
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'treatment_start_interval is submitted to be a fraction when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_start_interval: 0.5,
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'treatment_start_interval is submitted to be negative when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_start_interval: -0.2,
+				treatment_type: ['Ablation'],
+			}),
+		],
+	],
+	treatment_duration: [
+		[
+			'treatment_duration is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_duration: 40,
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'treatment_duration is missing when treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'treatment_duration is missing when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_duration is missing when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'treatment_duration is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_duration: 30,
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_duration is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				treatment_duration: 30,
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	is_primary_treatment: [
+		[
+			'is_primary_treatment is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				is_primary_treatment: 'No',
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'is_primary_treatment is missing  when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'is_primary_treatment is missing  when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'is_primary_treatment is empty when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				is_primary_treatment: '',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'is_primary_treatment is empty when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				is_primary_treatment: '',
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'is_primary_treatment is missing when treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'is_primary_treatment is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				is_primary_treatment: 'Yes',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'is_primary_treatment is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				is_primary_treatment: 'Yes',
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	treatment_setting: [
+		[
+			'treatment_setting is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_setting: 'adjuvant',
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'treatment_setting is missing when treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'treatment_setting is missing when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['no treatment'],
+			}),
+		],
+		[
+			'treatment_setting is missing when treatment was unknowm',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'treatment_setting is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_setting: 'neoadjuvant',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_setting is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				treatment_setting: 'neoadjuvant',
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	treatment_intent: [
+		[
+			'treatment_intent is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_intent: 'palliative',
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'treatment_intent is missing when treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'treatment_intent is not submitted when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_intent is not submitted when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'treatment_intent is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_intent: 'curative',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'treatment_intent is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				treatment_intent: 'curative',
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	days_per_cycle: [
+		[
+			'days per cycle is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				days_per_cycle: 12,
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'days per cycle is missing when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'days per cycle is missing when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'days per cycle is missing when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'days per cycle is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				days_per_cycle: 10,
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'days per cycle is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				days_per_cycle: 10,
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	outcome_of_treatment: [
+		[
+			'outcome_of_treatment is submitted when treatment was given',
+			true,
+			loadObjects(treatment, {
+				outcome_of_treatment: 'treatment completed as prescribed',
+				treatment_type: ['Chemotherapy'],
+			}),
+		],
+		[
+			'outcome_of_treatment is missing when treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Surgery'],
+			}),
+		],
+		[
+			'outcome_of_treatment is not applicable when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				outcome_of_treatment: 'Not Applicable',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'outcome_of_treatment is not applicable when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				outcome_of_treatment: 'Not Applicable',
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'outcome_of_treatment is empty when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				outcome_of_treatment: '',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'outcome_of_treatment is empty when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				outcome_of_treatment: '',
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'outcome_of_treatment is missing when no treatment was given',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'outcome_of_treatment is missing when treatment was unknown',
+			true,
+			loadObjects(treatment, {
+				treatment_type: ['Unknown'],
+			}),
+		],
+		[
+			'outcome_of_treatment is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				outcome_of_treatment: 'treatment completed as prescribed',
+				treatment_type: ['No treatment'],
+			}),
+		],
+		[
+			'outcome_of_treatment is submitted when treatment was unknown',
+			false,
+			loadObjects(treatment, {
+				outcome_of_treatment: 'treatment completed as prescribed',
+				treatment_type: ['Unknown'],
+			}),
+		],
+	],
+	response_to_treatment_criteria_method: [
+		[
+			'response_to_treatment_criteria_method is submitted when no treatment was given',
+			false,
+			loadObjects(treatment, {
+				response_to_treatment_criteria_method: 'RECIST',
+				treatment_type: ['no treatment'],
+			}),
+		],
+		[
+			'response_to_treatment_criteria_method is missing when radiation treatment was given',
+			false,
+			loadObjects(treatment, {
+				treatment_type: ['radiation therapy'],
+			}),
+		],
+	],
 };
 
 describe('Common Tests', () => {
-    Object.entries(myUnitTests).forEach(field => {
-        const name = field[0];
-        const unitTests = field[1];
+	Object.entries(myUnitTests).forEach(field => {
+		const name = field[0];
+		const unitTests = field[1];
 
-        unitTests.forEach(test => {
-            const testIndex = 2;
-            const testInputs = test[testIndex];
+		unitTests.forEach(test => {
+			const testIndex = 2;
+			const testInputs = test[testIndex];
 
-            universalTest(
-                validation()({ $row: testInputs, $name: name, $field: testInputs[name] }),
-            );
-        });
-    });
+			universalTest(validation()({ $row: testInputs, $name: name, $field: testInputs[name] }));
+		});
+	});
 });
 
 describe('Unit Tests for treatment fields when no treatment was given', () => {
-    Object.entries(myUnitTests).forEach(field => {
-        const name = field[0];
-        const unitTests = field[1];
+	Object.entries(myUnitTests).forEach(field => {
+		const name = field[0];
+		const unitTests = field[1];
 
-        describe(`Tests for the ${name} field.`, () => {
-            test.each(unitTests)(
-                '\n Test %# : %s \nExpecting result.valid to be: %s',
-                (description, target, inputs) => {
-                    const scriptOutput = validation()({
-                        $row: inputs,
-                        $field: inputs[name],
-                        $name: name,
-                    });
+		describe(`Tests for the ${name} field.`, () => {
+			test.each(unitTests)('Test %#: %s \n\tExpecting result.valid to be: %s', (description, target, inputs) => {
+				const scriptOutput = validation()({
+					$row: inputs,
+					$field: inputs[name],
+					$name: name,
+				});
 
-                    expect(scriptOutput.valid).toBe(target);
-                },
-            );
-        });
-    });
+				expect(scriptOutput.valid).toBe(target);
+			});
+		});
+	});
 });

--- a/tests/treatment/checkWhenNoTreatment.test.js
+++ b/tests/treatment/checkWhenNoTreatment.test.js
@@ -56,7 +56,7 @@ const myUnitTests = {
             'treatment_start_interval is submitted when treatment was unknown',
             false,
             loadObjects(treatment, {
-                treatment_start_interval: 30,
+                treatment_start_interval: 0,
                 treatment_type: ['Unknown'],
             }),
         ],
@@ -74,6 +74,14 @@ const myUnitTests = {
                 treatment_type: ['Unknown'],
             }),
         ],
+        [
+            'treatment_start_interval is submitted to be 0 when treatment was given',
+            true,
+            loadObjects(treatment, {
+                treatment_start_interval: 0,
+                treatment_type: ['Chemotherapy'],
+            }),
+      ],
     ],
     treatment_duration: [
         [


### PR DESCRIPTION
The issue (https://github.com/icgc-argo/argo-dictionary/issues/440) arises because the script treats the value `0` as falsy in the condition (!$field || $field === null || checkforEmpty($field)), so it incorrectly triggers the validation error.


## Steps To Test
<!--- Provide a link to a live example, or an unambiguous set of steps to>
<!--- reproduce this bug. Include code to reproduce, if relevant -->
Context:
 - Environment: QA
 - Program: MONSTAR-JP
 - Submitter Donor ID: MS0010022

Steps to test the behaviour:
1. Go to 'https://platform-ui.argo-qa.cumulus.genomeinformatics.org/' and login
2. Click on 'MONSTAR-JP' and tab 'Submit Clinical Data'
3. Click on 'UPLOAD FILES'
4. Submit the following test file
- [treatment_MS0010022.txt](https://github.com/user-attachments/files/17463266/treatment_MS0010022.txt)
5. Check the column 'treatment_start_interval' now accept value of `0`
6. Click on 'VALIDATE SUBMISSION' and no errors are showing up.
7. Go ahead to "SIGN OFF SUBMISSION"