### PR TITLE
Updated response_to_treatment field to include terms from RECIST 1.1 …

### DIFF
--- a/references/validationFunctions/treatment/responseToTreatment.js
+++ b/references/validationFunctions/treatment/responseToTreatment.js
@@ -91,6 +91,14 @@ const validation = () =>
             'physician assessed stable disease'
           ];
           break;
+        case 'recist 1.1':
+          codeList = [
+            'complete response',
+            'not evaluable (ne)',
+            'non-complete response/non-progressive disease (non-cr/non-pd)",
+            'progressive disease',
+          ];
+          break;
         default:
           codelist = [];
       }

--- a/references/validationFunctions/treatment/responseToTreatment.js
+++ b/references/validationFunctions/treatment/responseToTreatment.js
@@ -96,7 +96,9 @@ const validation = () =>
             'complete response',
             'not evaluable (ne)',
             'non-complete response/non-progressive disease (non-cr/non-pd)",
+            'partial response',
             'progressive disease',
+            'stable disease'
           ];
           break;
         default:

--- a/schemas/treatment.json
+++ b/schemas/treatment.json
@@ -242,6 +242,7 @@
           "IWG Cheson AML 2003 Oncology Response Criteria",
           "iRECIST",
           "RECIST",
+          "RECIST 1.1",
           "Response Assessment in Neuro-Oncology (RANO)",
           "Physician Assessed Response Criteria"
         ]
@@ -278,6 +279,8 @@
             "Morphologic complete remission with incomplete blood count recovery (CRi)",
             "Morphologic leukemia-free state",
             "No evidence of disease (NED)",
+            "Non-Complete response/Non-Progressive disease (Non-CR/Non-PD)",
+            "Not evaluable (NE)",
             "Partial remission",
             "Partial response",
             "Physician assessed complete response",


### PR DESCRIPTION
Related to issue https://github.com/icgc-argo/argo-dictionary/issues/447
Updated response_to_treatment field to include terms from RECIST 1.1 used for non-target lesions (Non-CR/Non-PD and NE).