### PR TITLE
Updated stageGroup validation script

### DIFF
--- a/references/validationFunctions/common/stageGroup.js
+++ b/references/validationFunctions/common/stageGroup.js
@@ -178,6 +178,10 @@ const validation = () =>
             'stage iab',
             'stage iiia',
             'stage iiib',
+            'stage iiic',
+            'stage iiic1',
+            'stage iiic2',
+            'stage iv',
             'stage iva',
             'stage ivb'
           ];


### PR DESCRIPTION
- Updated stageGroup validation script to include existing stage groups Stage IIIC, Stage IIIC1, Stage IIIC2 and Stage IV as part of a recent update to the FIGO staging system. This update will enable the P1000-US program to submit their data.
- Related to https://github.com/icgc-argo/argo-dictionary/issues/459